### PR TITLE
Add AGENTS instructions and begin test fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,4 @@
+- Agents may run `dotnet` commands, including adding NuGet packages with `dotnet add package`.
+- Always run `dotnet test` and ensure tests pass after modifications.
+- Focus development efforts on implementing missing functionality and fixing tests.
+- If required information is missing, request clarification.

--- a/MetricsPipeline.Tests/ReqnrollStartup.cs
+++ b/MetricsPipeline.Tests/ReqnrollStartup.cs
@@ -1,11 +1,16 @@
 using MetricsPipeline.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.EntityFrameworkCore;
+using Reqnroll;
+using Reqnroll.Microsoft.Extensions.DependencyInjection;
 
 public class ReqnrollStartup
 {
-    public void ConfigureServices(IServiceCollection services)
+    [ScenarioDependencies]
+    public static IServiceCollection CreateServices()
     {
+        var services = new ServiceCollection();
         services.AddMetricsPipeline(o => o.UseInMemoryDatabase("summaries"));
+        return services;
     }
 }

--- a/MetricsPipeline.Tests/Steps/CommitSteps.cs
+++ b/MetricsPipeline.Tests/Steps/CommitSteps.cs
@@ -35,11 +35,6 @@ public class CommitSteps
         _ctx["state"] = "valid";
     }
 
-    [Given(@"the summary is marked as invalid")]
-    public void GivenSummaryInvalid()
-    {
-        _ctx["state"] = "invalid";
-    }
 
     [Given(@"the database is temporarily unavailable")]
     public void GivenDbUnavailable()
@@ -113,7 +108,7 @@ public class CommitSteps
         res.IsSuccess.Should().BeFalse();
     }
 
-    [Then(@"the result should be (committed|discarded|error:unknown)")]
+    [Then(@"the result should be (.*)")]
     public void ThenResultShouldBe(string outcome)
     {
         var res = (PipelineResult<Unit>)_ctx["commitResult"];


### PR DESCRIPTION
## Summary
- document allowed actions in new AGENTS.md
- add ScenarioDependencies provider for Reqnroll tests
- fix ambiguous step definitions and data parsing

## Testing
- `dotnet test --filter "FullyQualifiedName~GatherApiData" -v minimal` *(fails: Expected res.IsSuccess to be False, but found True)*

------
https://chatgpt.com/codex/tasks/task_e_684f2e89f0948330976b8607ab9d7fcf