### PR TITLE
Fix step binding ambiguity

### DIFF
--- a/MetricsPipeline.Tests/Steps/CommitSteps.cs
+++ b/MetricsPipeline.Tests/Steps/CommitSteps.cs
@@ -95,6 +95,7 @@ public class CommitSteps
     }
 
     [Then(@"the operation should fail with reason ""(.*)""")]
+    [Scope(Feature = "CommitOrDiscardSummary")]
     public void ThenOperationFailReason(string reason)
     {
         var res = (PipelineResult<Unit>)_ctx["commitResult"];
@@ -109,6 +110,7 @@ public class CommitSteps
     }
 
     [Then(@"the result should be (.*)")]
+    [Scope(Feature = "CommitOrDiscardSummary")]
     public void ThenResultShouldBe(string outcome)
     {
         var res = (PipelineResult<Unit>)_ctx["commitResult"];

--- a/MetricsPipeline.Tests/Steps/IntegrationSteps.cs
+++ b/MetricsPipeline.Tests/Steps/IntegrationSteps.cs
@@ -28,6 +28,7 @@ public class IntegrationSteps
     }
 
     [Given(@"the last committed summary value is (.*)")]
+    [Scope(Feature = "FullPipelineExecution")]
     public void GivenLastCommitted(double val)
     {
         _db.Summaries.Add(new SummaryRecord { Source = _source, Value = val, Timestamp = DateTime.UtcNow.AddMinutes(-10) });

--- a/MetricsPipeline.Tests/Steps/SummarizeSteps.cs
+++ b/MetricsPipeline.Tests/Steps/SummarizeSteps.cs
@@ -41,6 +41,7 @@ public class SummarizeSteps
     }
 
     [Then(@"the result should be ([0-9.]+)")]
+    [Scope(Feature = "SummarizeMetricValues")]
     public void ThenResultShouldBeDouble(double expected)
     {
         var res = (PipelineResult<double>)_ctx["sumResult"];
@@ -48,6 +49,7 @@ public class SummarizeSteps
     }
 
     [Then(@"the operation should fail with reason ""(.*)""")]
+    [Scope(Feature = "SummarizeMetricValues")]
     public void ThenFailWith(string reason)
     {
         var res = (PipelineResult<double>)_ctx["sumResult"];

--- a/MetricsPipeline.Tests/Steps/ValidateSteps.cs
+++ b/MetricsPipeline.Tests/Steps/ValidateSteps.cs
@@ -15,6 +15,7 @@ public class ValidateSteps
     }
 
     [Given(@"the last committed summary value is (.*)")]
+    [Scope(Feature = "ValidateSummaryAgainstThreshold")]
     public void GivenLastCommitted(double last)
     {
         _ctx["last"] = last;


### PR DESCRIPTION
## Summary
- scope result steps by feature to avoid ambiguous step bindings
- fix other shared steps with feature scopes
- run unit tests

## Testing
- `dotnet test --verbosity minimal` *(fails: several assertion failures, no ambiguous steps)*

------
https://chatgpt.com/codex/tasks/task_e_684f33af52f0833086eb4db6b5e5a3d1