### PR TITLE
Fix step binding names

### DIFF
--- a/MetricsPipeline.Tests/Features/2288-commit-or-discard.feature
+++ b/MetricsPipeline.Tests/Features/2288-commit-or-discard.feature
@@ -20,7 +20,7 @@ Feature: CommitOrDiscardSummary
     Given the summary is valid
     And the database is temporarily unavailable
     When the system attempts to commit
-    Then the operation should fail with reason "DatabaseError"
+    Then the commit should fail with reason "DatabaseError"
     And the summary should remain uncommitted
 
   Scenario Outline: Outcome based on validation state

--- a/MetricsPipeline.Tests/Features/2288-summarize-metric-values.feature
+++ b/MetricsPipeline.Tests/Features/2288-summarize-metric-values.feature
@@ -30,7 +30,7 @@ Feature: SummarizeMetricValues
   Scenario: Handle summarization of empty input set
     Given there are no metric values to summarize
     When the system attempts to summarize using "average"
-    Then the operation should fail with reason "NoData"
+    Then the summarization should fail with reason "NoData"
 
   Scenario Outline: Use different strategies for same data
     Given the input metric values are:

--- a/MetricsPipeline.Tests/Steps/CommitSteps.cs
+++ b/MetricsPipeline.Tests/Steps/CommitSteps.cs
@@ -94,9 +94,9 @@ public class CommitSteps
         res.Error.Should().Be(reason);
     }
 
-    [Then(@"the operation should fail with reason ""(.*)""")]
+    [Then(@"the commit should fail with reason ""(.*)""")]
     [Scope(Feature = "CommitOrDiscardSummary")]
-    public void ThenOperationFailReason(string reason)
+    public void ThenCommitFailReason(string reason)
     {
         var res = (PipelineResult<Unit>)_ctx["commitResult"];
         res.Error.Should().Be(reason);

--- a/MetricsPipeline.Tests/Steps/SummarizeSteps.cs
+++ b/MetricsPipeline.Tests/Steps/SummarizeSteps.cs
@@ -48,9 +48,9 @@ public class SummarizeSteps
         res.Value.Should().Be(expected);
     }
 
-    [Then(@"the operation should fail with reason ""(.*)""")]
+    [Then(@"the summarization should fail with reason ""(.*)""")]
     [Scope(Feature = "SummarizeMetricValues")]
-    public void ThenFailWith(string reason)
+    public void ThenSummarizationFailWith(string reason)
     {
         var res = (PipelineResult<double>)_ctx["sumResult"];
         res.IsSuccess.Should().BeFalse();


### PR DESCRIPTION
## Summary
- rename summarization failure step
- rename commit failure step
- reference new steps in feature files

## Testing
- `dotnet test MetricsPipeline.Tests/MetricsPipeline.Tests.csproj --no-build`
- `dotnet test MetricsPipeline.Tests/MetricsPipeline.Tests.csproj --no-build --filter FullyQualifiedName~SummarizeMetricValues -v normal`

------
https://chatgpt.com/codex/tasks/task_e_684f38500a3883308d67a3e988b3e77e