### PR TITLE
Fix duplicate binding text

### DIFF
--- a/MetricsPipeline.Tests/Features/2288-integration-ingest-to-commit.feature
+++ b/MetricsPipeline.Tests/Features/2288-integration-ingest-to-commit.feature
@@ -3,7 +3,7 @@ Feature: FullPipelineExecution
 
   Background:
     Given the system is configured with a delta threshold of 5.0
-    And the last committed summary value is 45.0
+    And the previously committed summary value is 45.0
 
   Scenario: End-to-end success path with valid summary
     Given the API at "https://api.example.com/data" returns:

--- a/MetricsPipeline.Tests/Steps/IntegrationSteps.cs
+++ b/MetricsPipeline.Tests/Steps/IntegrationSteps.cs
@@ -27,7 +27,7 @@ public class IntegrationSteps
         _threshold = t;
     }
 
-    [Given(@"the last committed summary value is (.*)")]
+    [Given(@"the previously committed summary value is (.*)")]
     [Scope(Feature = "FullPipelineExecution")]
     public void GivenLastCommitted(double val)
     {


### PR DESCRIPTION
## Summary
- avoid duplicate binding text for last committed summary

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_684f3854928483308406e69f7041a103