### PR TITLE
Fix API return step regex quoting

### DIFF
--- a/MetricsPipeline.Tests/Steps/GatherSteps.cs
+++ b/MetricsPipeline.Tests/Steps/GatherSteps.cs
@@ -56,7 +56,7 @@ public class GatherSteps
         _ctx["gatherResult"] = result;
     }
 
-    [Given(@"the API endpoint (.*) returns content (.*)")]
+    [Given("the API endpoint \"(.*)\" returns content \"(.*)\"")]
     public void GivenEndpointReturnsContent(string endpoint, string content)
     {
         _ctx["endpoint"] = endpoint.Trim();


### PR DESCRIPTION
## Summary
- fix GatherSteps API content pattern to exclude outer quotes

## Testing
- `dotnet test --no-build` *(fails: Validate various summary values, Reject commit when summary exceeds threshold, End-to-end success path with valid summary, End-to-end failure due to invalid delta)*

------
https://chatgpt.com/codex/tasks/task_e_684f3857dee0833092d5d70fd8d51dcc