### PR TITLE
Fix logging when commit fails

### DIFF
--- a/MetricsPipeline.Tests/Steps/CommitSteps.cs
+++ b/MetricsPipeline.Tests/Steps/CommitSteps.cs
@@ -50,6 +50,7 @@ public class CommitSteps
         var now = DateTime.UtcNow;
         if (_ctx.ContainsKey("dbFail"))
         {
+            await _discard.HandleDiscardAsync(summary, "DatabaseError");
             _ctx["commitResult"] = PipelineResult<Unit>.Failure("DatabaseError");
         }
         else if ((string)_ctx["state"] == "valid")


### PR DESCRIPTION
## Summary
- log discard reason during commit failures

## Testing
- `dotnet test --no-build` *(fails: Validate various summary values, API returns malformed or unexpected data, Reject commit when summary exceeds threshold, End-to-end success path with valid summary, End-to-end failure due to invalid delta)*

------
https://chatgpt.com/codex/tasks/task_e_684f385ed63483309766d5e4ad045b63