### PR TITLE
Handle missing prior summary

### DIFF
--- a/MetricsPipeline.Infrastructure/Infrastructure/PipelineOrchestrator.cs
+++ b/MetricsPipeline.Infrastructure/Infrastructure/PipelineOrchestrator.cs
@@ -33,7 +33,13 @@ public class PipelineOrchestrator : IPipelineOrchestrator
         if (!summ.IsSuccess) return PipelineResult<PipelineState>.Failure(summ.Error!);
 
         var last = await _repo.GetLastCommittedAsync(source, ct);
-        if (!last.IsSuccess) return PipelineResult<PipelineState>.Failure(last.Error!);
+        if (!last.IsSuccess)
+        {
+            if (last.Error == "NoPriorSummary")
+                last = PipelineResult<double>.Success(0);
+            else
+                return PipelineResult<PipelineState>.Failure(last.Error!);
+        }
 
         var validation = _val.IsWithinThreshold(summ.Value!, last.Value!, threshold);
         if (!validation.IsSuccess) return PipelineResult<PipelineState>.Failure(validation.Error!);

--- a/MetricsPipeline.Tests/Features/2288-first-run-no-summary.feature
+++ b/MetricsPipeline.Tests/Features/2288-first-run-no-summary.feature
@@ -1,0 +1,14 @@
+Feature: FirstRunNoSummary
+  Runs pipeline when no prior summary exists.
+
+  Scenario: Run pipeline when no summary exists
+    Given the system is configured with a delta threshold of 50.0
+    And the API at "https://api.example.com/data" returns:
+      | MetricValue |
+      | 44.5 |
+      | 45.0 |
+      | 45.5 |
+    When the pipeline is executed
+    Then the summary should be 45.0
+    And the delta from last run should be 45.0
+    And the summary should be committed successfully


### PR DESCRIPTION
## Summary
- allow PipelineOrchestrator to continue when no prior summary is found
- add a feature file that exercises running the pipeline with no previous summary

## Testing
- `dotnet test MetricsPipeline.Tests -v q` *(fails: Validate various summary values ...)*

------
https://chatgpt.com/codex/tasks/task_e_684f3b2d5bec8330a42a864bda82f414