### PR TITLE
Add generic DI registration and worker

### DIFF
--- a/MetricsPipeline.Infrastructure/Infrastructure/DependencyInjection.cs
+++ b/MetricsPipeline.Infrastructure/Infrastructure/DependencyInjection.cs
@@ -6,8 +6,12 @@ using Microsoft.EntityFrameworkCore;
 public static class DependencyInjection
 {
     public static IServiceCollection AddMetricsPipeline(this IServiceCollection services, Action<DbContextOptionsBuilder> dbCfg)
+        => services.AddMetricsPipeline<SummaryDbContext>(dbCfg);
+
+    public static IServiceCollection AddMetricsPipeline<TContext>(this IServiceCollection services, Action<DbContextOptionsBuilder> dbCfg)
+        where TContext : SummaryDbContext
     {
-        services.AddDbContext<SummaryDbContext>(dbCfg);
+        services.AddDbContext<SummaryDbContext, TContext>(dbCfg);
         // Use a scoped lifetime for the in-memory gather service so that
         // the orchestrator and step definitions share the same instance
         // within a single scenario while avoiding cross-scenario state.
@@ -18,6 +22,7 @@ public static class DependencyInjection
         services.AddTransient<IDiscardHandler, LoggingDiscardHandler>();
         services.AddTransient<ISummaryRepository, EfSummaryRepository>();
         services.AddTransient<IPipelineOrchestrator, PipelineOrchestrator>();
+        services.AddHostedService<PipelineWorker>();
         return services;
     }
 }

--- a/MetricsPipeline.Infrastructure/Infrastructure/PipelineWorker.cs
+++ b/MetricsPipeline.Infrastructure/Infrastructure/PipelineWorker.cs
@@ -1,0 +1,20 @@
+using MetricsPipeline.Core;
+using Microsoft.Extensions.Hosting;
+
+namespace MetricsPipeline.Infrastructure;
+
+public class PipelineWorker : BackgroundService
+{
+    private readonly IPipelineOrchestrator _orchestrator;
+
+    public PipelineWorker(IPipelineOrchestrator orchestrator)
+    {
+        _orchestrator = orchestrator;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var source = new Uri("https://api.example.com/data");
+        await _orchestrator.ExecuteAsync(source, SummaryStrategy.Average, 5.0, stoppingToken);
+    }
+}

--- a/MetricsPipeline.Infrastructure/MetricsPipeline.Infrastructure.csproj
+++ b/MetricsPipeline.Infrastructure/MetricsPipeline.Infrastructure.csproj
@@ -10,5 +10,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- allow specifying custom `DbContext` type when adding MetricsPipeline services
- integrate a `PipelineWorker` hosted service
- update infrastructure project dependencies

## Testing
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_684f3f5bc1008330b10bcb7d7050902b