### PR TITLE
Add repository/unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 **/bin/
 **/obj/
+*.feature.cs
 *.binlog

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,5 @@
 - Agents may run `dotnet` commands, including adding NuGet packages with `dotnet add package`.
+- When introducing new functionality, first add BDD feature files and step definitions to cover the behavior.
 - Always run `dotnet test` and ensure tests pass after modifications.
 - Focus development efforts on implementing missing functionality and fixing tests.
 - If required information is missing, request clarification.

--- a/MetricsPipeline.Core/Core/Repository.cs
+++ b/MetricsPipeline.Core/Core/Repository.cs
@@ -1,0 +1,14 @@
+namespace MetricsPipeline.Core;
+
+public interface IRepository<TEntity> where TEntity : class
+{
+    Task<TEntity?> GetByIdAsync(object id, CancellationToken ct = default);
+    Task AddAsync(TEntity entity, CancellationToken ct = default);
+    void Remove(TEntity entity);
+}
+
+public interface IUnitOfWork
+{
+    IRepository<TEntity> Repository<TEntity>() where TEntity : class;
+    Task<int> SaveChangesAsync(CancellationToken ct = default);
+}

--- a/MetricsPipeline.Infrastructure/Infrastructure/EfRepository.cs
+++ b/MetricsPipeline.Infrastructure/Infrastructure/EfRepository.cs
@@ -1,0 +1,23 @@
+namespace MetricsPipeline.Infrastructure;
+using MetricsPipeline.Core;
+using Microsoft.EntityFrameworkCore;
+
+public class EfRepository<TEntity> : IRepository<TEntity> where TEntity : class
+{
+    protected readonly DbContext _context;
+    protected readonly DbSet<TEntity> _set;
+
+    public EfRepository(DbContext context)
+    {
+        _context = context;
+        _set = context.Set<TEntity>();
+    }
+
+    public Task<TEntity?> GetByIdAsync(object id, CancellationToken ct = default)
+        => _set.FindAsync([id], ct).AsTask();
+
+    public Task AddAsync(TEntity entity, CancellationToken ct = default)
+        => _set.AddAsync(entity, ct).AsTask();
+
+    public void Remove(TEntity entity) => _set.Remove(entity);
+}

--- a/MetricsPipeline.Infrastructure/Infrastructure/RepositoryExtensions.cs
+++ b/MetricsPipeline.Infrastructure/Infrastructure/RepositoryExtensions.cs
@@ -1,0 +1,22 @@
+namespace MetricsPipeline.Infrastructure;
+using MassTransit;
+using MetricsPipeline.Core;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+public static class RepositoryExtensions
+{
+    public static IServiceCollection AddRepositoriesAndSagas<TContext>(
+        this IServiceCollection services,
+        Action<DbContextOptionsBuilder> dbCfg,
+        Action<IBusRegistrationConfigurator>? busCfg = null)
+        where TContext : DbContext
+    {
+        services.AddDbContext<TContext>(dbCfg);
+        services.AddScoped<DbContext>(p => p.GetRequiredService<TContext>());
+        services.AddScoped(typeof(IRepository<>), typeof(EfRepository<>));
+        services.AddScoped<IUnitOfWork, UnitOfWork<TContext>>();
+        services.AddMassTransit(cfg => busCfg?.Invoke(cfg));
+        return services;
+    }
+}

--- a/MetricsPipeline.Infrastructure/Infrastructure/UnitOfWork.cs
+++ b/MetricsPipeline.Infrastructure/Infrastructure/UnitOfWork.cs
@@ -1,0 +1,19 @@
+namespace MetricsPipeline.Infrastructure;
+using MetricsPipeline.Core;
+using Microsoft.EntityFrameworkCore;
+
+public class UnitOfWork<TContext> : IUnitOfWork where TContext : DbContext
+{
+    private readonly TContext _context;
+
+    public UnitOfWork(TContext context)
+    {
+        _context = context;
+    }
+
+    public IRepository<TEntity> Repository<TEntity>() where TEntity : class
+        => new EfRepository<TEntity>(_context);
+
+    public Task<int> SaveChangesAsync(CancellationToken ct = default)
+        => _context.SaveChangesAsync(ct);
+}

--- a/MetricsPipeline.Infrastructure/MetricsPipeline.Infrastructure.csproj
+++ b/MetricsPipeline.Infrastructure/MetricsPipeline.Infrastructure.csproj
@@ -11,5 +11,6 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
+    <PackageReference Include="MassTransit" Version="8.0.0" />
   </ItemGroup>
 </Project>

--- a/MetricsPipeline.Tests/Features/3000-repositories-and-sagas.feature
+++ b/MetricsPipeline.Tests/Features/3000-repositories-and-sagas.feature
@@ -1,0 +1,13 @@
+Feature: RepositoriesAndSagas
+  Verify repository, unit of work and MassTransit DI setup.
+
+  Scenario: Services are registered
+    Then a repository should be provided
+    And a unit of work should be provided
+    And the bus should be provided
+
+  Scenario: Persist and retrieve a summary record
+    Given a new summary record with value 12.3
+    When the record is added and saved
+    And the record is retrieved
+    Then the retrieved value should be 12.3

--- a/MetricsPipeline.Tests/MetricsPipeline.Tests.csproj
+++ b/MetricsPipeline.Tests/MetricsPipeline.Tests.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="FluentAssertions" Version="6.13.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.0" />
+    <PackageReference Include="MassTransit" Version="8.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Using Include="Xunit" />

--- a/MetricsPipeline.Tests/ReqnrollStartup.cs
+++ b/MetricsPipeline.Tests/ReqnrollStartup.cs
@@ -1,4 +1,5 @@
 using MetricsPipeline.Infrastructure;
+using MassTransit;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.EntityFrameworkCore;
 using Reqnroll;
@@ -13,6 +14,9 @@ public class ReqnrollStartup
         // Use a unique in-memory database for each scenario to avoid
         // cross-test interference when persisting summaries.
         services.AddMetricsPipeline(o => o.UseInMemoryDatabase(Guid.NewGuid().ToString()));
+        services.AddRepositoriesAndSagas<SummaryDbContext>(
+            o => o.UseInMemoryDatabase(Guid.NewGuid().ToString()),
+            cfg => cfg.UsingInMemory((context, c) => { }));
         return services;
     }
 }

--- a/MetricsPipeline.Tests/Steps/RepositorySteps.cs
+++ b/MetricsPipeline.Tests/Steps/RepositorySteps.cs
@@ -1,0 +1,65 @@
+using MetricsPipeline.Infrastructure;
+using MetricsPipeline.Core;
+using MassTransit;
+using Reqnroll;
+using FluentAssertions;
+
+[Binding]
+public class RepositorySteps
+{
+    private readonly IRepository<SummaryRecord> _repo;
+    private readonly IUnitOfWork _uow;
+    private readonly IBus _bus;
+    private SummaryRecord? _record;
+    private SummaryRecord? _result;
+
+    public RepositorySteps(IRepository<SummaryRecord> repo, IUnitOfWork uow, IBus bus)
+    {
+        _repo = repo;
+        _uow = uow;
+        _bus = bus;
+    }
+
+    [Then("a repository should be provided")]
+    public void ThenRepositoryProvided()
+    {
+        _repo.Should().NotBeNull();
+    }
+
+    [Then("a unit of work should be provided")]
+    public void ThenUnitOfWorkProvided()
+    {
+        _uow.Should().NotBeNull();
+    }
+
+    [Then("the bus should be provided")]
+    public void ThenBusProvided()
+    {
+        _bus.Should().NotBeNull();
+    }
+
+    [Given("a new summary record with value (.*)")]
+    public void GivenNewRecord(double value)
+    {
+        _record = new SummaryRecord { Value = value, Source = new("https://test") , Timestamp = DateTime.UtcNow };
+    }
+
+    [When("the record is added and saved")]
+    public async Task WhenRecordAddedAndSaved()
+    {
+        await _repo.AddAsync(_record!);
+        await _uow.SaveChangesAsync();
+    }
+
+    [When("the record is retrieved")]
+    public async Task WhenRecordRetrieved()
+    {
+        _result = await _repo.GetByIdAsync(_record!.Id);
+    }
+
+    [Then("the retrieved value should be (.*)")]
+    public void ThenRetrievedValue(double value)
+    {
+        _result!.Value.Should().Be(value);
+    }
+}


### PR DESCRIPTION
## Summary
- update AGENTS docs to require BDD tests first
- register DbContext with generic DI extension
- wire extension in test startup and add MassTransit reference
- add BDD feature and step definitions for repository/unit of work DI
- ignore generated feature.cs files

## Testing
- `dotnet test --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_684f40f2e7008330ac0d79071e919b9e