### PR TITLE
Add additional BDD tests for Unit of Work and strategy errors

### DIFF
--- a/MetricsPipeline.Tests/Features/3100-unit-of-work.feature
+++ b/MetricsPipeline.Tests/Features/3100-unit-of-work.feature
@@ -1,0 +1,17 @@
+Feature: UnitOfWorkCommit
+  Ensure repository changes persist when SaveChanges is invoked.
+
+  Scenario: Persist new record through Unit of Work
+    Given a new summary record with value 55.5
+    When the record is added and saved
+    And the record is retrieved
+    Then the retrieved value should be 55.5
+
+  Scenario: Removing a record and committing
+    Given a new summary record with value 10.0
+    When the record is added and saved
+    And the record is retrieved
+    Then the retrieved value should be 10.0
+    When the record is deleted and saved
+    And the record is retrieved
+    Then no record should be found

--- a/MetricsPipeline.Tests/Features/3200-invalid-summarization-strategy.feature
+++ b/MetricsPipeline.Tests/Features/3200-invalid-summarization-strategy.feature
@@ -1,0 +1,9 @@
+Feature: InvalidSummarizationStrategy
+  Ensure summarization fails for unsupported strategies.
+
+  Scenario: Summarization with unknown strategy
+    Given the input metric values are:
+      | MetricValue |
+      | 1.0 |
+    When the system attempts to summarize using "invalid"
+    Then the summarization should fail with reason "UnknownStrategy"

--- a/MetricsPipeline.Tests/Steps/SummarizeSteps.cs
+++ b/MetricsPipeline.Tests/Steps/SummarizeSteps.cs
@@ -30,7 +30,9 @@ public class SummarizeSteps
     public void WhenSystemSummarizes(string strategy)
     {
         var metrics = (List<double>)_ctx["metrics"];
-        var res = _sum.Summarize(metrics, Enum.Parse<SummaryStrategy>(strategy, true));
+        if (!Enum.TryParse<SummaryStrategy>(strategy, true, out var strat))
+            strat = (SummaryStrategy)(-1);
+        var res = _sum.Summarize(metrics, strat);
         _ctx["sumResult"] = res;
     }
 
@@ -55,5 +57,12 @@ public class SummarizeSteps
         var res = (PipelineResult<double>)_ctx["sumResult"];
         res.IsSuccess.Should().BeFalse();
         res.Error.Should().Be(reason);
+    }
+
+    [Then(@"the summarization should fail with reason ""(.*)""")]
+    [Scope(Feature = "InvalidSummarizationStrategy")]
+    public void ThenSummarizationFailInvalid(string reason)
+    {
+        ThenSummarizationFailWith(reason);
     }
 }

--- a/MetricsPipeline.Tests/Steps/UnitOfWorkSteps.cs
+++ b/MetricsPipeline.Tests/Steps/UnitOfWorkSteps.cs
@@ -1,0 +1,72 @@
+using MetricsPipeline.Infrastructure;
+using MetricsPipeline.Core;
+using Reqnroll;
+using FluentAssertions;
+
+namespace MetricsPipeline.Tests.Steps;
+
+[Binding]
+[Scope(Feature = "UnitOfWorkCommit")]
+public class UnitOfWorkSteps
+{
+    private readonly IRepository<SummaryRecord> _repo;
+    private readonly IUnitOfWork _uow;
+    private SummaryRecord? _record;
+    private SummaryRecord? _result;
+
+    public UnitOfWorkSteps(IRepository<SummaryRecord> repo, IUnitOfWork uow)
+    {
+        _repo = repo;
+        _uow = uow;
+    }
+
+    [Given("a new summary record with value (.*)")]
+    public void GivenNewRecord(double value)
+    {
+        _record = new SummaryRecord { Value = value, Source = new("https://test"), Timestamp = DateTime.UtcNow };
+    }
+
+    [When("the record is added without saving")]
+    public async Task WhenAddedWithoutSaving()
+    {
+        await _repo.AddAsync(_record!);
+    }
+
+    [When("the record is added and saved")]
+    public async Task WhenAddedAndSaved()
+    {
+        await _repo.AddAsync(_record!);
+        await _uow.SaveChangesAsync();
+    }
+
+    [When("the changes are committed")]
+    public async Task WhenChangesCommitted()
+    {
+        await _uow.SaveChangesAsync();
+    }
+
+    [When("the record is deleted and saved")]
+    public async Task WhenDeletedAndSaved()
+    {
+        _repo.Remove(_record!);
+        await _uow.SaveChangesAsync();
+    }
+
+    [When("the record is retrieved")]
+    public async Task WhenRetrieved()
+    {
+        _result = await _repo.GetByIdAsync(_record!.Id);
+    }
+
+    [Then("no record should be found")]
+    public void ThenNoRecordFound()
+    {
+        _result.Should().BeNull();
+    }
+
+    [Then("the retrieved value should be (.*)")]
+    public void ThenRetrievedValue(double value)
+    {
+        _result!.Value.Should().Be(value);
+    }
+}


### PR DESCRIPTION
## Summary
- add feature for verifying UnitOfWork commit behavior
- add feature for invalid summarization strategy
- implement UnitOfWorkSteps and extend SummarizeSteps for strategy errors
- update summarization steps to handle unknown strategies

## Testing
- `dotnet test MetricsPipeline.sln -v normal`

------
https://chatgpt.com/codex/tasks/task_e_684fed9567e48330969fa87845302624