### PR TITLE
Implement stage strategy worker

### DIFF
--- a/MetricsPipeline.Console/PipelineWorker.cs
+++ b/MetricsPipeline.Console/PipelineWorker.cs
@@ -6,17 +6,35 @@ namespace MetricsPipeline.Infrastructure;
 public class PipelineWorker : BackgroundService
 {
     private readonly IPipelineOrchestrator _orchestrator;
+    private readonly List<string> _executed = new();
+
+    /// <summary>
+    /// Gets the messages returned by each executed stage.
+    /// </summary>
+    public IReadOnlyList<string> ExecutedStages => _executed;
 
     public PipelineWorker(IPipelineOrchestrator orchestrator)
     {
         _orchestrator = orchestrator;
     }
 
+
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
+        RunStage(TaskStage.Gather);
+        RunStage(TaskStage.Validate);
+
         var source = new Uri("https://api.example.com/data");
         var result = await _orchestrator.ExecuteAsync(source, SummaryStrategy.Average, 5.0, stoppingToken);
-        Console.WriteLine($"Success: {result.IsSuccess}");
-        Console.WriteLine($"Summary: {result.Value.Summary}");
+
+        RunStage(result.IsSuccess ? TaskStage.Commit : TaskStage.Revert);
+    }
+
+    private void RunStage(TaskStage stage)
+    {
+        var strategy = TaskStrategyFactory.Create(stage);
+        var outcome = strategy.Execute();
+        _executed.Add(outcome.Value!);
+        Console.WriteLine(outcome.Value);
     }
 }

--- a/MetricsPipeline.Core/Core/TaskExecution.cs
+++ b/MetricsPipeline.Core/Core/TaskExecution.cs
@@ -1,0 +1,20 @@
+namespace MetricsPipeline.Core;
+
+/// <summary>
+/// Pipeline stages supported by the execution strategy framework.
+/// </summary>
+public enum TaskStage
+{
+    Gather,
+    Validate,
+    Commit,
+    Revert
+}
+
+public interface ITaskExecutionStrategy
+{
+    /// <summary>
+    /// Execute the behaviour for a particular pipeline stage.
+    /// </summary>
+    PipelineResult<string> Execute();
+}

--- a/MetricsPipeline.Core/Infrastructure/TaskExecutionStrategies.cs
+++ b/MetricsPipeline.Core/Infrastructure/TaskExecutionStrategies.cs
@@ -1,0 +1,34 @@
+namespace MetricsPipeline.Infrastructure;
+using MetricsPipeline.Core;
+
+public class GatherStrategy : ITaskExecutionStrategy
+{
+    public PipelineResult<string> Execute() => PipelineResult<string>.Success("Gathered");
+}
+
+public class ValidateStrategy : ITaskExecutionStrategy
+{
+    public PipelineResult<string> Execute() => PipelineResult<string>.Success("Validated");
+}
+
+public class CommitStrategy : ITaskExecutionStrategy
+{
+    public PipelineResult<string> Execute() => PipelineResult<string>.Success("Committed");
+}
+
+public class RevertStrategy : ITaskExecutionStrategy
+{
+    public PipelineResult<string> Execute() => PipelineResult<string>.Success("Reverted");
+}
+
+public static class TaskStrategyFactory
+{
+    public static ITaskExecutionStrategy Create(TaskStage stage) => stage switch
+    {
+        TaskStage.Gather => new GatherStrategy(),
+        TaskStage.Validate => new ValidateStrategy(),
+        TaskStage.Commit => new CommitStrategy(),
+        TaskStage.Revert => new RevertStrategy(),
+        _ => throw new ArgumentOutOfRangeException(nameof(stage))
+    };
+}

--- a/MetricsPipeline.Tests/Features/3400-task-execution-strategy.feature
+++ b/MetricsPipeline.Tests/Features/3400-task-execution-strategy.feature
@@ -1,0 +1,14 @@
+Feature: TaskExecutionStrategy
+  Verify correct strategy selection for pipeline stages.
+
+  Scenario Outline: Execute <Stage> stage
+    Given a task stage "<Stage>"
+    When the task executor runs
+    Then the result message should be "<Message>"
+
+    Examples:
+      | Stage    | Message   |
+      | Gather   | Gathered  |
+      | Validate | Validated |
+      | Commit   | Committed |
+      | Revert   | Reverted  |

--- a/MetricsPipeline.Tests/Features/3410-worker-stage-execution.feature
+++ b/MetricsPipeline.Tests/Features/3410-worker-stage-execution.feature
@@ -1,0 +1,12 @@
+Feature: WorkerStageExecution
+  Verify the PipelineWorker executes the correct stages based on the orchestrator result.
+
+  Scenario Outline: Worker handles <Outcome> result
+    Given the worker is configured for <Outcome>
+    When the worker runs
+    Then the stage results should be "<Stages>"
+
+    Examples:
+      | Outcome | Stages                       |
+      | success | Gathered,Validated,Committed |
+      | failure | Gathered,Validated,Reverted  |

--- a/MetricsPipeline.Tests/MetricsPipeline.Tests.csproj
+++ b/MetricsPipeline.Tests/MetricsPipeline.Tests.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="../MetricsPipeline.Core/MetricsPipeline.Core.csproj" />
+    <ProjectReference Include="../MetricsPipeline.Console/MetricsPipeline.Console.csproj" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />

--- a/MetricsPipeline.Tests/Steps/PipelineWorkerSteps.cs
+++ b/MetricsPipeline.Tests/Steps/PipelineWorkerSteps.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using MetricsPipeline.Core;
+using MetricsPipeline.Infrastructure;
+using Reqnroll;
+
+namespace MetricsPipeline.Tests.Steps;
+
+// Simple orchestrator used to control success or failure in tests
+internal class FakeOrchestrator : IPipelineOrchestrator
+{
+    private readonly bool _success;
+    public FakeOrchestrator(bool success) { _success = success; }
+
+    public Task<PipelineResult<PipelineState>> ExecuteAsync(Uri source, SummaryStrategy strategy, double threshold, CancellationToken ct = default)
+    {
+        if (_success)
+        {
+            var state = new PipelineState(source, Array.Empty<double>(), 0, 0, threshold, DateTime.UtcNow);
+            return Task.FromResult(PipelineResult<PipelineState>.Success(state));
+        }
+        return Task.FromResult(PipelineResult<PipelineState>.Failure("fail"));
+    }
+}
+
+// Exposes the protected ExecuteAsync method for testing
+internal class TestWorker : PipelineWorker
+{
+    public TestWorker(IPipelineOrchestrator orchestrator) : base(orchestrator) { }
+    public Task RunAsync() => base.ExecuteAsync(CancellationToken.None);
+}
+
+[Binding]
+[Scope(Feature = "WorkerStageExecution")]
+public class PipelineWorkerSteps
+{
+    private TestWorker _worker = null!;
+
+    [Given("the worker is configured for (.*)")]
+    public void GivenWorkerConfigured(string outcome)
+    {
+        bool success = outcome == "success";
+        _worker = new TestWorker(new FakeOrchestrator(success));
+    }
+
+    [When("the worker runs")]
+    public async Task WhenWorkerRuns()
+    {
+        await _worker.RunAsync();
+    }
+
+    [Then("the stage results should be \"(.*)\"")]
+    public void ThenResultsShouldBe(string expected)
+    {
+        var parts = expected.Split(',');
+        _worker.ExecutedStages.Should().Equal(parts);
+    }
+}

--- a/MetricsPipeline.Tests/Steps/TaskStrategySteps.cs
+++ b/MetricsPipeline.Tests/Steps/TaskStrategySteps.cs
@@ -1,0 +1,35 @@
+using MetricsPipeline.Core;
+using MetricsPipeline.Infrastructure;
+using Reqnroll;
+using FluentAssertions;
+
+namespace MetricsPipeline.Tests.Steps;
+
+[Binding]
+[Scope(Feature = "TaskExecutionStrategy")]
+public class TaskStrategySteps
+{
+    private TaskStage _stage;
+    private PipelineResult<string>? _result;
+
+    [Given("a task stage \"(.*)\"")]
+    public void GivenTaskStage(string stage)
+    {
+        _stage = Enum.Parse<TaskStage>(stage, true);
+    }
+
+    [When("the task executor runs")]
+    [When("the task executor runs the operation")]
+    public void WhenTaskExecutorRuns()
+    {
+        var strategy = TaskStrategyFactory.Create(_stage);
+        _result = strategy.Execute();
+    }
+
+    [Then("the result message should be \"(.*)\"")]
+    [Then("the result should be \"(.*)\"")]
+    public void ThenResultShouldBe(string message)
+    {
+        _result!.Value.Should().Be(message);
+    }
+}


### PR DESCRIPTION
## Summary
- expose stage results in `PipelineWorker`
- add BDD feature for worker stage execution and steps to drive the worker
- reference the console project from the test project

## Testing
- `dotnet test --verbosity minimal`


------
https://chatgpt.com/codex/tasks/task_e_684ff75f524c83308eeb8ddabe4ca939