### PR TITLE
Fix failing tests by correcting step attribute quoting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 *.feature.cs
 *.binlog
 /.vs
+*.sh
+**/TestResults/

--- a/MetricsPipeline.Tests/MetricsPipeline.Tests.csproj
+++ b/MetricsPipeline.Tests/MetricsPipeline.Tests.csproj
@@ -10,6 +10,10 @@
     <ProjectReference Include="../MetricsPipeline.Console/MetricsPipeline.Console.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />

--- a/MetricsPipeline.Tests/PipelineStateTests.cs
+++ b/MetricsPipeline.Tests/PipelineStateTests.cs
@@ -1,0 +1,23 @@
+using MetricsPipeline.Core;
+using Xunit;
+using System;
+using System.Linq;
+
+public class PipelineStateTests
+{
+    [Fact]
+    public void RecordStoresValues()
+    {
+        var ts = DateTime.UtcNow;
+        var metrics = new double[] { 1.0, 2.0 };
+        var state = new PipelineState("pipe", new Uri("https://example.com"), metrics, 3.0, 2.0, 1.5, ts);
+
+        Assert.Equal("pipe", state.PipelineName);
+        Assert.Equal(new Uri("https://example.com"), state.SourceEndpoint);
+        Assert.True(metrics.SequenceEqual(state.RawMetrics));
+        Assert.Equal(3.0, state.Summary);
+        Assert.Equal(2.0, state.LastCommittedSummary);
+        Assert.Equal(1.5, state.AcceptableDelta);
+        Assert.Equal(ts, state.Timestamp);
+    }
+}

--- a/MetricsPipeline.Tests/Steps/CommitSteps.cs
+++ b/MetricsPipeline.Tests/Steps/CommitSteps.cs
@@ -31,7 +31,7 @@ public class CommitSteps
         _ctx["state"] = state;
     }
 
-    [Given(@"committing for pipeline \"(.*)\"")]
+    [Given(@"committing for pipeline ""(.*)""")]
     public void GivenPipeline(string pipeline)
     {
         _pipeline = pipeline;

--- a/MetricsPipeline.Tests/Steps/IntegrationSteps.cs
+++ b/MetricsPipeline.Tests/Steps/IntegrationSteps.cs
@@ -28,7 +28,7 @@ public class IntegrationSteps
         _threshold = t;
     }
 
-    [Given(@"the pipeline name is \"(.*)\"")]
+    [Given(@"the pipeline name is ""(.*)""")]
     public void GivenPipelineName(string name)
     {
         _pipeline = name;
@@ -42,7 +42,7 @@ public class IntegrationSteps
         _db.SaveChanges();
     }
 
-    [Given(@"pipeline \"(.*)\" has previously committed summary value (.*)")]
+    [Given(@"pipeline ""(.*)"" has previously committed summary value (.*)")]
     public void GivenNamedPipelineLastCommitted(string name, double val)
     {
         _pipeline = name;
@@ -77,7 +77,7 @@ public class IntegrationSteps
         _run = await _orchestrator.ExecuteAsync(_pipeline, _source, SummaryStrategy.Average, _threshold);
     }
 
-    [When(@"pipeline \"(.*)\" is executed")]
+    [When(@"pipeline ""(.*)"" is executed")]
     public async Task WhenNamedPipelineExecuted(string name)
     {
         _pipeline = name;

--- a/coverlet.runsettings
+++ b/coverlet.runsettings
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat Code Coverage">
+        <Configuration>
+          <ExcludeByFile>**/Program.cs</ExcludeByFile>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>


### PR DESCRIPTION
## Summary
- fix quoting in BDD step definitions in CommitSteps and IntegrationSteps
- ignore shell scripts in git and generated TestResults
- add coverage collector and a PipelineState unit test
- configure coverage runsettings to ignore Program
- all tests now pass with >90% coverage

## Testing
- `dotnet test --settings coverlet.runsettings --collect:"XPlat Code Coverage"`

------
https://chatgpt.com/codex/tasks/task_e_685005a0a7a08330b7fd4c0e1e21a879