### PR TITLE
Implement entity scanning in SummaryDbContext

### DIFF
--- a/MetricsPipeline.Core/Core/Entities.cs
+++ b/MetricsPipeline.Core/Core/Entities.cs
@@ -7,7 +7,9 @@ public interface IBaseEntity
     int Id { get; set; }
 }
 
-public interface IRootEntity { }
+public interface IEntity { }
+
+public interface IRootEntity : IEntity { }
 
 public interface ISoftDelete
 {

--- a/MetricsPipeline.Core/Infrastructure/EFCore.cs
+++ b/MetricsPipeline.Core/Infrastructure/EFCore.cs
@@ -1,4 +1,5 @@
 namespace MetricsPipeline.Infrastructure;
+using System.Reflection;
 using MetricsPipeline.Core;
 using Microsoft.EntityFrameworkCore;
 
@@ -17,4 +18,21 @@ public class SummaryDbContext : DbContext
     public DbSet<SummaryRecord> Summaries => Set<SummaryRecord>();
 
     public SummaryDbContext(DbContextOptions<SummaryDbContext> options) : base(options) { }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        var assembly = Assembly.GetExecutingAssembly();
+        var entityTypes = assembly.GetTypes()
+            .Where(t => typeof(IEntity).IsAssignableFrom(t)
+                        && typeof(ISoftDelete).IsAssignableFrom(t)
+                        && t.IsClass && !t.IsAbstract);
+
+        foreach (var type in entityTypes)
+        {
+            modelBuilder.Entity(type);
+        }
+
+        modelBuilder.ApplyConfigurationsFromAssembly(assembly);
+        base.OnModelCreating(modelBuilder);
+    }
 }

--- a/MetricsPipeline.Tests/Features/4000-gather-entities.feature
+++ b/MetricsPipeline.Tests/Features/4000-gather-entities.feature
@@ -1,0 +1,6 @@
+Feature: GatherEntities
+  Ensures SummaryDbContext automatically registers entity types.
+
+  Scenario: Model registers entities from assembly
+    When the database model is built
+    Then the SummaryRecord entity should be mapped

--- a/MetricsPipeline.Tests/Steps/GatherEntitiesSteps.cs
+++ b/MetricsPipeline.Tests/Steps/GatherEntitiesSteps.cs
@@ -1,0 +1,31 @@
+using FluentAssertions;
+using MetricsPipeline.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Reqnroll;
+
+namespace MetricsPipeline.Tests.Steps;
+
+[Binding]
+[Scope(Feature = "GatherEntities")]
+public class GatherEntitiesSteps
+{
+    private readonly SummaryDbContext _db;
+    private IModel? _model;
+
+    public GatherEntitiesSteps(SummaryDbContext db)
+    {
+        _db = db;
+    }
+
+    [When("the database model is built")]
+    public void WhenModelBuilt()
+    {
+        _model = _db.Model;
+    }
+
+    [Then("the SummaryRecord entity should be mapped")]
+    public void ThenSummaryRecordMapped()
+    {
+        _model!.FindEntityType(typeof(SummaryRecord)).Should().NotBeNull();
+    }
+}


### PR DESCRIPTION
## Summary
- add `IEntity` marker interface and extend `IRootEntity`
- scan assembly for `IEntity` implementations in `SummaryDbContext`
- create BDD specs to confirm entity scanning
- implement step definitions for new specs

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68502b7b6e9083308a39bf06920c708a