### PR TITLE
Add seeding service and tests

### DIFF
--- a/MetricsPipeline.Console/Seed/SeedDataService.cs
+++ b/MetricsPipeline.Console/Seed/SeedDataService.cs
@@ -1,0 +1,57 @@
+using System.Text.Json;
+using System.Linq.Expressions;
+using MetricsPipeline.Core;
+using MetricsPipeline.Infrastructure;
+
+namespace MetricsPipeline.Seeding;
+
+public class SeedDataService
+{
+    private readonly IGenericRepository<SummaryRecord> _repo;
+    private readonly IUnitOfWork _uow;
+    private readonly string _seedDir;
+
+    public SeedDataService(IGenericRepository<SummaryRecord> repo, IUnitOfWork uow, string seedDir)
+    {
+        _repo = repo;
+        _uow = uow;
+        _seedDir = seedDir;
+    }
+
+    public async Task SeedAsync()
+    {
+        if (!Directory.Exists(_seedDir)) return;
+
+        foreach (var file in Directory.GetFiles(_seedDir, "*.json"))
+        {
+            string json = await File.ReadAllTextAsync(file);
+            List<SummaryRecord>? records;
+            try
+            {
+                records = JsonSerializer.Deserialize<List<SummaryRecord>>(json, new JsonSerializerOptions
+                {
+                    PropertyNameCaseInsensitive = true
+                });
+            }
+            catch (JsonException ex)
+            {
+                throw new SeedValidationException(Path.GetFileName(file), (int)(ex.LineNumber ?? 0), ex);
+            }
+
+            if (records == null) continue;
+            foreach (var record in records)
+            {
+                var count = await _repo.GetCountAsync(new ExistsSpec(record.PipelineName, record.Source, record.Timestamp));
+                if (count == 0)
+                    await _repo.AddAsync(record);
+            }
+        }
+        await _uow.SaveChangesAsync();
+    }
+
+    private record ExistsSpec(string Name, Uri Source, DateTime Timestamp) : ISpecification<SummaryRecord>
+    {
+        public Expression<Func<SummaryRecord, bool>> Criteria => r =>
+            r.PipelineName == Name && r.Source == Source && r.Timestamp == Timestamp;
+    }
+}

--- a/MetricsPipeline.Console/Seed/SeedValidationException.cs
+++ b/MetricsPipeline.Console/Seed/SeedValidationException.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace MetricsPipeline.Seeding;
+
+public class SeedValidationException : Exception
+{
+    public string FileName { get; }
+    public int LineNumber { get; }
+
+    public SeedValidationException(string fileName, int lineNumber, Exception inner)
+        : base($"Invalid seed data in {fileName} at line {lineNumber}", inner)
+    {
+        FileName = fileName;
+        LineNumber = lineNumber;
+    }
+}

--- a/MetricsPipeline.Tests/Features/4020-validate-seeding.feature
+++ b/MetricsPipeline.Tests/Features/4020-validate-seeding.feature
@@ -1,0 +1,31 @@
+Feature: ValidateSeeding
+  Seeds the database from JSON files.
+
+  Scenario: Insert records from JSON
+    Given a seed file "seed.json" containing:
+      """
+      [
+        { "PipelineName": "demo", "Source": "https://ex.com", "Value": 5, "Timestamp": "2024-01-01T00:00:00Z" }
+      ]
+      """
+    When the seeding service is executed
+    Then the repository should contain 1 record
+
+  Scenario: Skip duplicate records
+    Given a seed file "seed.json" containing:
+      """
+      [
+        { "PipelineName": "demo", "Source": "https://ex.com", "Value": 5, "Timestamp": "2024-01-01T00:00:00Z" }
+      ]
+      """
+    And the seeding service is executed
+    When the seeding service is executed
+    Then the repository should contain 1 record
+
+  Scenario: Malformed JSON raises error
+    Given a seed file "bad.json" containing:
+      """
+      [ { "PipelineName": "demo", }
+      """
+    When executing the seeding service
+    Then a SeedValidationException should be thrown for "bad.json" line 0

--- a/MetricsPipeline.Tests/Steps/SeedSteps.cs
+++ b/MetricsPipeline.Tests/Steps/SeedSteps.cs
@@ -1,0 +1,82 @@
+using System.Text;
+using MetricsPipeline.Core;
+using MetricsPipeline.Infrastructure;
+using MetricsPipeline.Seeding;
+using Reqnroll;
+using FluentAssertions;
+
+namespace MetricsPipeline.Tests.Steps;
+
+[Binding]
+[Scope(Feature = "ValidateSeeding")]
+public class SeedSteps
+{
+    private readonly IGenericRepository<SummaryRecord> _repo;
+    private readonly IUnitOfWork _uow;
+    private readonly ScenarioContext _ctx;
+    private string _dir = string.Empty;
+
+    public SeedSteps(IGenericRepository<SummaryRecord> repo, IUnitOfWork uow, ScenarioContext ctx)
+    {
+        _repo = repo;
+        _uow = uow;
+        _ctx = ctx;
+    }
+
+    [BeforeScenario]
+    public void Setup()
+    {
+        _dir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(Path.Combine(_dir, "Seeds"));
+    }
+
+    [AfterScenario]
+    public void Cleanup()
+    {
+        if (Directory.Exists(_dir))
+            Directory.Delete(_dir, true);
+    }
+
+    [Given(@"a seed file ""(.*)"" containing:")]
+    public void GivenSeedFile(string file, string content)
+    {
+        File.WriteAllText(Path.Combine(_dir, "Seeds", file), content.Trim());
+    }
+
+    [Given(@"the seeding service is executed")]
+    [When(@"the seeding service is executed")]
+    public async Task WhenServiceExecuted()
+    {
+        var svc = new SeedDataService(_repo, _uow, Path.Combine(_dir, "Seeds"));
+        try
+        {
+            await svc.SeedAsync();
+        }
+        catch (Exception ex)
+        {
+            _ctx["error"] = ex;
+        }
+    }
+
+    [When(@"executing the seeding service")]
+    public async Task WhenExecutingService()
+    {
+        await WhenServiceExecuted();
+    }
+
+    [Then(@"the repository should contain (\d+) record(?:s)?")]
+    public async Task ThenRepositoryCount(int expected)
+    {
+        var count = await _repo.GetCountAsync();
+        count.Should().Be(expected);
+    }
+
+    [Then(@"a SeedValidationException should be thrown for ""(.*)"" line (\d+)")]
+    public void ThenException(string file, int line)
+    {
+        _ctx.Should().ContainKey("error");
+        var ex = _ctx["error"].Should().BeOfType<SeedValidationException>().Subject;
+        ex.FileName.Should().Be(file);
+        ex.LineNumber.Should().Be(line);
+    }
+}

--- a/TestData/Seeds/sample.json
+++ b/TestData/Seeds/sample.json
@@ -1,0 +1,8 @@
+[
+  {
+    "PipelineName": "demo",
+    "Source": "https://example.com",
+    "Value": 1.0,
+    "Timestamp": "2024-01-01T00:00:00Z"
+  }
+]


### PR DESCRIPTION
## Summary
- create `SeedDataService` and `SeedValidationException`
- add sample seed data
- introduce feature file for seeding and remove ignore tag
- implement SeedSteps step definitions

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68502b8cdde48330b4ea698a3da73e23