### PR TITLE
Add EF in-memory provider feature

### DIFF
--- a/MetricsPipeline.Tests/Features/4040-revert-inmemory.feature
+++ b/MetricsPipeline.Tests/Features/4040-revert-inmemory.feature
@@ -1,0 +1,8 @@
+Feature: RevertInMemoryDatabase
+  Ensures the in-memory provider can be initialized without migrations.
+
+  Scenario: Initialize in-memory database
+    Given a new in-memory SummaryDbContext
+    When the context is inspected
+    Then migrations should not run
+    And the database is empty

--- a/MetricsPipeline.Tests/MetricsPipeline.Tests.csproj
+++ b/MetricsPipeline.Tests/MetricsPipeline.Tests.csproj
@@ -14,6 +14,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />

--- a/MetricsPipeline.Tests/Steps/RevertInMemorySteps.cs
+++ b/MetricsPipeline.Tests/Steps/RevertInMemorySteps.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Linq;
+using FluentAssertions;
+using MetricsPipeline.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+using Reqnroll;
+
+namespace MetricsPipeline.Tests.Steps;
+
+[Binding]
+[Scope(Feature = "RevertInMemoryDatabase")]
+public class RevertInMemorySteps
+{
+    private readonly SummaryDbContext _db;
+
+    public RevertInMemorySteps(SummaryDbContext db)
+    {
+        _db = db;
+    }
+
+    [Given("a new in-memory SummaryDbContext")]
+    public void GivenContext()
+    {
+        _db.Database.EnsureCreated();
+    }
+
+    [When("the context is inspected")]
+    public void WhenInspected()
+    {
+        // no-op, inspection occurs in assertions
+    }
+
+    [Then("migrations should not run")]
+    public void ThenMigrationsSkipped()
+    {
+        _db.Database.ProviderName.Should().Be("Microsoft.EntityFrameworkCore.InMemory");
+    }
+
+    [Then("the database is empty")]
+    public void ThenSeededExists()
+    {
+        _db.Summaries.Count().Should().Be(0);
+    }
+}


### PR DESCRIPTION
## Summary
- allow selecting SQLite or EF InMemory provider with `DB_PROVIDER`
- generate a new database name for each DbContext creation
- add BDD scenario `4040-revert-inmemory.feature`
- implement step definitions for verifying in-memory setup
- include SQLite provider in test project

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68502b8e36348330954820d05a9328da