### PR TITLE
Implement async repository CRUD and tests

### DIFF
--- a/MetricsPipeline.Core/Core/GenericRepository.cs
+++ b/MetricsPipeline.Core/Core/GenericRepository.cs
@@ -3,6 +3,9 @@ namespace MetricsPipeline.Core;
 public interface IGenericRepository<T>
     where T : class, ISoftDelete, IBaseEntity, IRootEntity
 {
+    Task<int> CreateAsync(T entity);
+    Task<int> UpdateAsync(T entity);
+    Task<int> DeleteAsync(T entity, bool hardDelete);
     Task AddAsync(T entity);
     Task AddRangeAsync(IEnumerable<T> entities);
     Task<IReadOnlyList<T>> GetAllAsync(params string[] includeStrings);

--- a/MetricsPipeline.Core/Core/HardDeleteNotPermittedException.cs
+++ b/MetricsPipeline.Core/Core/HardDeleteNotPermittedException.cs
@@ -1,0 +1,6 @@
+namespace MetricsPipeline.Core;
+
+public class HardDeleteNotPermittedException : Exception
+{
+    public HardDeleteNotPermittedException() : base("Hard delete is not permitted") {}
+}

--- a/MetricsPipeline.Tests/Features/4030-commit-repository.feature
+++ b/MetricsPipeline.Tests/Features/4030-commit-repository.feature
@@ -1,0 +1,31 @@
+Feature: CommitRepository
+  Validate async create, update and delete operations on the generic repository
+
+  Scenario: Create returns key
+    Given a summary record with value 5.0 for commit repo
+    When the record is created via repository
+    Then the created id should be greater than 0
+
+  Scenario: Update returns key
+    Given a summary record with value 3.0 for commit repo
+    And the record is created via repository
+    When the record value is updated to 6.0 via repository
+    Then the updated id should equal the created id
+
+  Scenario: Soft delete sets flag
+    Given a summary record with value 2.0 for commit repo
+    And the record is created via repository
+    When the record is softly deleted via repository
+    Then the record should be marked deleted
+
+  Scenario: Hard delete blocked when not allowed
+    Given a summary record with value 4.0 for commit repo
+    And the record is created via repository
+    When a hard delete is attempted via repository
+    Then a HardDeleteNotPermittedException should be thrown
+
+  Scenario: Hard delete allowed when repository configured
+    Given a summary record with value 7.0 for commit repo with hard delete
+    When a hard delete is attempted via repository
+    Then the delete result id should equal the created id
+    And retrieving the deleted record should return nothing

--- a/MetricsPipeline.Tests/Steps/CommitRepositorySteps.cs
+++ b/MetricsPipeline.Tests/Steps/CommitRepositorySteps.cs
@@ -1,0 +1,110 @@
+using MetricsPipeline.Infrastructure;
+using MetricsPipeline.Core;
+using FluentAssertions;
+using Reqnroll;
+using System.Linq;
+
+namespace MetricsPipeline.Tests.Steps;
+
+[Binding]
+[Scope(Feature = "CommitRepository")]
+public class CommitRepositorySteps
+{
+    private readonly SummaryDbContext _db;
+    private IGenericRepository<SummaryRecord> _repo;
+    private SummaryRecord? _record;
+    private int _resultId;
+    private int _createdId;
+    private Exception? _ex;
+    private SummaryRecord? _retrieved;
+
+    public CommitRepositorySteps(IGenericRepository<SummaryRecord> repo, SummaryDbContext db)
+    {
+        _repo = repo;
+        _db = db;
+    }
+
+    [Given("a summary record with value (.*) for commit repo")]
+    public void GivenRecord(double val)
+    {
+        _record = new SummaryRecord { PipelineName = "test", Value = val, Source = new("https://test"), Timestamp = DateTime.UtcNow };
+    }
+
+    [Given("a summary record with value (.*) for commit repo with hard delete")]
+    public void GivenRecordWithHardDelete(double val)
+    {
+        _record = new SummaryRecord { PipelineName = "test", Value = val, Source = new("https://test"), Timestamp = DateTime.UtcNow };
+        _repo = new EfGenericRepository<SummaryRecord>(_db, true);
+    }
+
+    [Given("the record is created via repository")]
+    [When("the record is created via repository")]
+    public async Task WhenRecordCreated()
+    {
+        _createdId = await _repo.CreateAsync(_record!);
+    }
+
+    [When("the record value is updated to (.*) via repository")]
+    public async Task WhenRecordUpdated(double val)
+    {
+        _record!.Value = val;
+        _resultId = await _repo.UpdateAsync(_record);
+    }
+
+    [When("the record is softly deleted via repository")]
+    public async Task WhenSoftDelete()
+    {
+        _resultId = await _repo.DeleteAsync(_record!, false);
+    }
+
+    [When("a hard delete is attempted via repository")]
+    public async Task WhenHardDelete()
+    {
+        try
+        {
+            _resultId = await _repo.DeleteAsync(_record!, true);
+        }
+        catch(Exception ex)
+        {
+            _ex = ex;
+        }
+    }
+
+    [Then("the created id should be greater than 0")]
+    public void ThenCreatedId()
+    {
+        _createdId.Should().BeGreaterThan(0);
+    }
+
+    [Then("the updated id should equal the created id")]
+    public void ThenUpdateId()
+    {
+        _resultId.Should().Be(_createdId);
+    }
+
+    [Then("the record should be marked deleted")]
+    public void ThenMarkedDeleted()
+    {
+        var entity = _db.Summaries.First(e => e.Id == _createdId);
+        entity.IsDeleted.Should().BeTrue();
+    }
+
+    [Then("a HardDeleteNotPermittedException should be thrown")]
+    public void ThenHardDeleteException()
+    {
+        _ex.Should().BeOfType<HardDeleteNotPermittedException>();
+    }
+
+    [Then("the delete result id should equal the created id")]
+    public void ThenHardDeleteSuccessId()
+    {
+        _resultId.Should().Be(_createdId);
+    }
+
+    [Then("retrieving the deleted record should return nothing")]
+    public async Task ThenRetrievingDeleted()
+    {
+        _retrieved = await _repo.GetByIdAsync(_createdId);
+        _retrieved.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary
- extend `IGenericRepository` with async create, update, delete returning ids
- enforce hard delete permissions with new exception
- implement logic in `EfGenericRepository`
- cover create/update/delete paths in new `CommitRepository` feature

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68502b8da6408330ac03071586352ea0