### PR TITLE
Implement soft delete query filter with opt-out

### DIFF
--- a/MetricsPipeline.Core/Core/GenericRepository.cs
+++ b/MetricsPipeline.Core/Core/GenericRepository.cs
@@ -3,6 +3,7 @@ namespace MetricsPipeline.Core;
 public interface IGenericRepository<T>
     where T : class, ISoftDelete, IBaseEntity, IRootEntity
 {
+    bool IgnoreSoftDeleteFilter { get; set; }
     Task<int> CreateAsync(T entity);
     Task<int> UpdateAsync(T entity);
     Task<int> DeleteAsync(T entity, bool hardDelete);

--- a/MetricsPipeline.Core/Infrastructure/EFCore.cs
+++ b/MetricsPipeline.Core/Infrastructure/EFCore.cs
@@ -1,5 +1,6 @@
 namespace MetricsPipeline.Infrastructure;
 using System.Reflection;
+using System.Linq.Expressions;
 using MetricsPipeline.Core;
 using Microsoft.EntityFrameworkCore;
 
@@ -29,7 +30,12 @@ public class SummaryDbContext : DbContext
 
         foreach (var type in entityTypes)
         {
-            modelBuilder.Entity(type);
+            var entity = modelBuilder.Entity(type);
+            var param = Expression.Parameter(type, "e");
+            var prop = Expression.Property(param, nameof(ISoftDelete.IsDeleted));
+            var condition = Expression.Equal(prop, Expression.Constant(false));
+            var lambda = Expression.Lambda(condition, param);
+            entity.HasQueryFilter(lambda);
         }
 
         modelBuilder.ApplyConfigurationsFromAssembly(assembly);

--- a/MetricsPipeline.Tests/Features/4010-summarize-softdelete.feature
+++ b/MetricsPipeline.Tests/Features/4010-summarize-softdelete.feature
@@ -1,0 +1,13 @@
+Feature: SoftDeleteFilter
+  Validates global soft delete filtering and repository opt-out
+
+  Scenario: Deleted summaries excluded by default
+    Given a soft deleted summary record exists
+    When counting all summaries
+    Then the summary count should be 0
+
+  Scenario: Deleted summaries included when filter ignored
+    Given a soft deleted summary record exists
+    And the repository ignores the soft delete filter
+    When counting all summaries
+    Then the summary count should be 1

--- a/MetricsPipeline.Tests/Steps/CommitRepositorySteps.cs
+++ b/MetricsPipeline.Tests/Steps/CommitRepositorySteps.cs
@@ -3,6 +3,7 @@ using MetricsPipeline.Core;
 using FluentAssertions;
 using Reqnroll;
 using System.Linq;
+using Microsoft.EntityFrameworkCore;
 
 namespace MetricsPipeline.Tests.Steps;
 
@@ -85,7 +86,7 @@ public class CommitRepositorySteps
     [Then("the record should be marked deleted")]
     public void ThenMarkedDeleted()
     {
-        var entity = _db.Summaries.First(e => e.Id == _createdId);
+        var entity = _db.Summaries.IgnoreQueryFilters().First(e => e.Id == _createdId);
         entity.IsDeleted.Should().BeTrue();
     }
 

--- a/MetricsPipeline.Tests/Steps/SoftDeleteFilterSteps.cs
+++ b/MetricsPipeline.Tests/Steps/SoftDeleteFilterSteps.cs
@@ -1,0 +1,55 @@
+using FluentAssertions;
+using MetricsPipeline.Core;
+using MetricsPipeline.Infrastructure;
+using Reqnroll;
+
+namespace MetricsPipeline.Tests.Steps;
+
+[Binding]
+[Scope(Feature = "SoftDeleteFilter")]
+public class SoftDeleteFilterSteps
+{
+    private readonly SummaryDbContext _db;
+    private readonly IGenericRepository<SummaryRecord> _repo;
+    private int _count;
+
+    public SoftDeleteFilterSteps(SummaryDbContext db, IGenericRepository<SummaryRecord> repo)
+    {
+        _db = db;
+        _repo = repo;
+    }
+
+    [Given("a soft deleted summary record exists")]
+    public void GivenSoftDeletedRecord()
+    {
+        var rec = new SummaryRecord
+        {
+            PipelineName = "demo",
+            Source = new("https://example.com"),
+            Timestamp = DateTime.UtcNow,
+            Value = 1.0,
+            IsDeleted = true
+        };
+        _db.Summaries.Add(rec);
+        _db.SaveChanges();
+    }
+
+    [Given("the repository ignores the soft delete filter")]
+    public void GivenIgnoreFilter()
+    {
+        if (_repo is EfGenericRepository<SummaryRecord> ef)
+            ef.IgnoreSoftDeleteFilter = true;
+    }
+
+    [When("counting all summaries")]
+    public async Task WhenCountingAll()
+    {
+        _count = await _repo.GetCountAsync();
+    }
+
+    [Then("the summary count should be (\\d+)")]
+    public void ThenSummaryCount(int expected)
+    {
+        _count.Should().Be(expected);
+    }
+}


### PR DESCRIPTION
## Summary
- add global soft-delete filter to `SummaryDbContext`
- allow repositories to bypass filter via `IgnoreSoftDeleteFilter`
- update commit repository tests for new filter
- validate filter behaviour with new BDD scenarios

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68502e6145a483309792841758b7cd86