### PR TITLE
Enable dynamic gather stage for orchestrator

### DIFF
--- a/MetricsPipeline.Core/Core/Contracts.cs
+++ b/MetricsPipeline.Core/Core/Contracts.cs
@@ -123,6 +123,7 @@ namespace MetricsPipeline.Core
             Uri source,
             SummaryStrategy strategy,
             double threshold,
-            CancellationToken ct = default);
+            CancellationToken ct = default,
+            string gatherMethodName = nameof(IGatherService.FetchMetricsAsync));
     }
 }

--- a/MetricsPipeline.Core/Infrastructure/InMemoryGatherService.cs
+++ b/MetricsPipeline.Core/Infrastructure/InMemoryGatherService.cs
@@ -32,4 +32,10 @@ public class InMemoryGatherService : IGatherService
             ? Task.FromResult(PipelineResult<IReadOnlyList<double>>.Failure("NoData"))
             : Task.FromResult(PipelineResult<IReadOnlyList<double>>.Success(set));
     }
+
+    /// <summary>
+    /// Alternate gather method used for testing dynamic selection.
+    /// </summary>
+    public Task<PipelineResult<IReadOnlyList<double>>> CustomGatherAsync(Uri source, CancellationToken ct = default)
+        => FetchMetricsAsync(source, ct);
 }

--- a/MetricsPipeline.Tests/Features/3420-custom-gather-method.feature
+++ b/MetricsPipeline.Tests/Features/3420-custom-gather-method.feature
@@ -1,0 +1,13 @@
+Feature: CustomGatherMethod
+  Verify the orchestrator can use a specified gather method.
+
+  Scenario: Execute pipeline using alternate gather method
+    Given the gather method is "CustomGatherAsync"
+    And the API at "https://api.example.com/data" returns:
+      | MetricValue |
+      | 44.5 |
+      | 45.0 |
+      | 45.5 |
+    When the pipeline is executed
+    Then the summary should be 45.0
+    And the summary should be committed successfully

--- a/MetricsPipeline.Tests/Steps/IntegrationSteps.cs
+++ b/MetricsPipeline.Tests/Steps/IntegrationSteps.cs
@@ -21,6 +21,7 @@ public class IntegrationSteps
     private Uri _source = new("https://api.example.com/data");
     private double _threshold = 5.0;
     private string _pipeline = "default";
+    private string _gatherMethod = "FetchMetricsAsync";
 
     [Given(@"the system is configured with a delta threshold of (.*)")]
     public void GivenThreshold(double t)
@@ -32,6 +33,12 @@ public class IntegrationSteps
     public void GivenPipelineName(string name)
     {
         _pipeline = name;
+    }
+
+    [Given(@"the gather method is \"(.*)\"")]
+    public void GivenGatherMethod(string method)
+    {
+        _gatherMethod = method;
     }
 
     [Given(@"the previously committed summary value is (.*)")]
@@ -74,7 +81,7 @@ public class IntegrationSteps
     [When(@"the pipeline is executed")]
     public async Task WhenPipelineExecuted()
     {
-        _run = await _orchestrator.ExecuteAsync(_pipeline, _source, SummaryStrategy.Average, _threshold);
+        _run = await _orchestrator.ExecuteAsync(_pipeline, _source, SummaryStrategy.Average, _threshold, default, _gatherMethod);
     }
 
     [When(@"pipeline ""(.*)"" is executed")]

--- a/MetricsPipeline.Tests/Steps/PipelineWorkerSteps.cs
+++ b/MetricsPipeline.Tests/Steps/PipelineWorkerSteps.cs
@@ -15,7 +15,7 @@ internal class FakeOrchestrator : IPipelineOrchestrator
     private readonly bool _success;
     public FakeOrchestrator(bool success) { _success = success; }
 
-    public Task<PipelineResult<PipelineState>> ExecuteAsync(string name, Uri source, SummaryStrategy strategy, double threshold, CancellationToken ct = default)
+    public Task<PipelineResult<PipelineState>> ExecuteAsync(string name, Uri source, SummaryStrategy strategy, double threshold, CancellationToken ct = default, string gatherMethodName = "FetchMetricsAsync")
     {
         if (_success)
         {
@@ -27,9 +27,16 @@ internal class FakeOrchestrator : IPipelineOrchestrator
 }
 
 // Exposes the protected ExecuteAsync method for testing
+internal class FakeGatherService : IGatherService
+{
+    public Task<PipelineResult<IReadOnlyList<double>>> FetchMetricsAsync(Uri source, CancellationToken ct = default)
+        => Task.FromResult(PipelineResult<IReadOnlyList<double>>.Success(new List<double>{1.0,2.0}));
+}
+
 internal class TestWorker : PipelineWorker
 {
-    public TestWorker(IPipelineOrchestrator orchestrator) : base(orchestrator) { }
+    public TestWorker(IPipelineOrchestrator orchestrator)
+        : base(orchestrator, new FakeGatherService()) { }
     public Task RunAsync() => base.ExecuteAsync(CancellationToken.None);
 }
 


### PR DESCRIPTION
## Summary
- inject gather service into `PipelineWorker` and run gather/validate steps
- allow `PipelineOrchestrator.ExecuteAsync` to select gather method by name
- add alternate gather method to `InMemoryGatherService`
- extend integration steps with configurable gather method
- test worker stage execution with new dependencies
- add feature covering custom gather method

## Testing
- `dotnet test --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_68503eeb08a483309e06881d089f2f91