### PR TITLE
Add demo API and HTTP client with Aspire host

### DIFF
--- a/MetricsPipeline.AppHost/MetricsPipeline.AppHost.csproj
+++ b/MetricsPipeline.AppHost/MetricsPipeline.AppHost.csproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Aspire.Hosting" Version="8.0.0-preview.3.23270.1" />
+    <ProjectReference Include="../MetricsPipeline.DemoApi/MetricsPipeline.DemoApi.csproj" />
+    <ProjectReference Include="../MetricsPipeline.Console/MetricsPipeline.Console.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/MetricsPipeline.AppHost/Program.cs
+++ b/MetricsPipeline.AppHost/Program.cs
@@ -1,0 +1,8 @@
+using Aspire.Hosting;
+
+var builder = DistributedApplication.CreateBuilder(args);
+
+builder.AddProject("demoapi", "../MetricsPipeline.DemoApi/MetricsPipeline.DemoApi.csproj");
+builder.AddProject("worker", "../MetricsPipeline.Console/MetricsPipeline.Console.csproj");
+
+builder.Build().Run();

--- a/MetricsPipeline.Console/MetricsPipeline.Console.csproj
+++ b/MetricsPipeline.Console/MetricsPipeline.Console.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.0" />
   </ItemGroup>
 
 </Project>

--- a/MetricsPipeline.Console/PipelineWorker.cs
+++ b/MetricsPipeline.Console/PipelineWorker.cs
@@ -35,7 +35,7 @@ public class PipelineWorker : BackgroundService
         await RunStageAsync(TaskStage.Gather, stoppingToken);
         await RunStageAsync(TaskStage.Validate, stoppingToken);
 
-        var source = new Uri("https://api.example.com/data");
+        var source = new Uri("http://localhost:5000/metrics");
         var result = await _orchestrator.ExecuteAsync("demo", source, SummaryStrategy.Average, 5.0, stoppingToken);
 
         await RunStageAsync(result.IsSuccess ? TaskStage.Commit : TaskStage.Revert, stoppingToken);
@@ -46,7 +46,7 @@ public class PipelineWorker : BackgroundService
         switch (stage)
         {
             case TaskStage.Gather:
-                var gatherResult = await _gather.FetchMetricsAsync(new Uri("https://api.example.com/data"), ct);
+                var gatherResult = await _gather.FetchMetricsAsync(new Uri("http://localhost:5000/metrics"), ct);
                 _gathered = gatherResult.IsSuccess ? gatherResult.Value : Array.Empty<double>();
                 _executed.Add("Gathered");
                 Console.WriteLine("Gathered");

--- a/MetricsPipeline.Console/Program.cs
+++ b/MetricsPipeline.Console/Program.cs
@@ -2,12 +2,19 @@
 using MetricsPipeline.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Hosting;
+using System;
+using MetricsPipeline.Core;
 using Microsoft.Extensions.DependencyInjection;
 
 var host = Host.CreateDefaultBuilder(args)
     .ConfigureServices(services =>
     {
         services.AddMetricsPipeline(o => o.UseInMemoryDatabase("demo"));
+        services.AddHttpClient<HttpMetricsClient>(c =>
+        {
+            c.BaseAddress = new Uri("http://localhost:5000");
+        });
+        services.AddTransient<IGatherService, HttpGatherService>();
         services.AddHostedService<PipelineWorker>();
     })
     .Build();

--- a/MetricsPipeline.Core/Infrastructure/HttpGatherService.cs
+++ b/MetricsPipeline.Core/Infrastructure/HttpGatherService.cs
@@ -1,0 +1,33 @@
+namespace MetricsPipeline.Infrastructure;
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using MetricsPipeline.Core;
+
+public class HttpGatherService : IGatherService
+{
+    private readonly HttpMetricsClient _client;
+
+    public HttpGatherService(HttpMetricsClient client)
+    {
+        _client = client;
+    }
+
+    public async Task<PipelineResult<IReadOnlyList<double>>> FetchMetricsAsync(Uri source, CancellationToken ct = default)
+    {
+        try
+        {
+            var data = await _client.SendAsync<double>(HttpMethod.Get, source.ToString(), ct);
+            return PipelineResult<IReadOnlyList<double>>.Success(data!);
+        }
+        catch (Exception ex)
+        {
+            return PipelineResult<IReadOnlyList<double>>.Failure(ex.Message);
+        }
+    }
+
+    public Task<PipelineResult<IReadOnlyList<double>>> CustomGatherAsync(Uri source, CancellationToken ct = default)
+        => FetchMetricsAsync(source, ct);
+}

--- a/MetricsPipeline.Core/Infrastructure/HttpMetricsClient.cs
+++ b/MetricsPipeline.Core/Infrastructure/HttpMetricsClient.cs
@@ -1,0 +1,26 @@
+using System.Net.Http;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+namespace MetricsPipeline.Infrastructure;
+
+public class HttpMetricsClient
+{
+    private readonly HttpClient _client;
+
+    public HttpMetricsClient(HttpClient client)
+    {
+        _client = client;
+    }
+
+    public async Task<IReadOnlyList<T>?> SendAsync<T>(HttpMethod method, string uri, CancellationToken ct = default)
+    {
+        using var request = new HttpRequestMessage(method, uri);
+        var response = await _client.SendAsync(request, ct);
+        response.EnsureSuccessStatusCode();
+        var json = await response.Content.ReadAsStringAsync(ct);
+        var data = System.Text.Json.JsonSerializer.Deserialize<List<T>>(json);
+        return data ?? new List<T>();
+    }
+}

--- a/MetricsPipeline.DemoApi/MetricsPipeline.DemoApi.csproj
+++ b/MetricsPipeline.DemoApi/MetricsPipeline.DemoApi.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.6" />
+  </ItemGroup>
+
+</Project>

--- a/MetricsPipeline.DemoApi/MetricsPipeline.DemoApi.http
+++ b/MetricsPipeline.DemoApi/MetricsPipeline.DemoApi.http
@@ -1,0 +1,6 @@
+@MetricsPipeline.DemoApi_HostAddress = http://localhost:5019
+
+GET {{MetricsPipeline.DemoApi_HostAddress}}/weatherforecast/
+Accept: application/json
+
+###

--- a/MetricsPipeline.DemoApi/Program.cs
+++ b/MetricsPipeline.DemoApi/Program.cs
@@ -1,0 +1,20 @@
+var builder = WebApplication.CreateBuilder(args);
+builder.Services.AddOpenApi();
+
+var app = builder.Build();
+
+// Configure the HTTP request pipeline.
+if (app.Environment.IsDevelopment())
+{
+    app.MapOpenApi();
+}
+
+app.MapGet("/metrics", () => new[] { 42.0, 43.1, 41.7 })
+   .WithName("GetMetrics");
+
+app.Run();
+
+namespace MetricsPipeline.DemoApi
+{
+    public partial class Program { }
+}

--- a/MetricsPipeline.DemoApi/Properties/launchSettings.json
+++ b/MetricsPipeline.DemoApi/Properties/launchSettings.json
@@ -1,0 +1,23 @@
+﻿{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "http://localhost:5019",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "https://localhost:7126;http://localhost:5019",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/MetricsPipeline.DemoApi/appsettings.Development.json
+++ b/MetricsPipeline.DemoApi/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/MetricsPipeline.DemoApi/appsettings.json
+++ b/MetricsPipeline.DemoApi/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/MetricsPipeline.Tests/Features/4500-demo-api-integration.feature
+++ b/MetricsPipeline.Tests/Features/4500-demo-api-integration.feature
@@ -1,0 +1,7 @@
+Feature: DemoApiIntegration
+  Verify that the generic HTTP client can retrieve metrics from the demo API
+
+  Scenario: Fetch metrics from the demo API
+    Given the demo API is running
+    When the http client requests "http://localhost:5000/metrics" using GET
+    Then the response list should contain 3 items

--- a/MetricsPipeline.Tests/MetricsPipeline.Tests.csproj
+++ b/MetricsPipeline.Tests/MetricsPipeline.Tests.csproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <ProjectReference Include="../MetricsPipeline.Core/MetricsPipeline.Core.csproj" />
     <ProjectReference Include="../MetricsPipeline.Console/MetricsPipeline.Console.csproj" />
+    <ProjectReference Include="../MetricsPipeline.DemoApi/MetricsPipeline.DemoApi.csproj" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4">
@@ -26,6 +27,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.0" />
     <PackageReference Include="MassTransit" Version="8.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Using Include="Xunit" />

--- a/MetricsPipeline.Tests/ReqnrollStartup.cs
+++ b/MetricsPipeline.Tests/ReqnrollStartup.cs
@@ -22,6 +22,7 @@ public class ReqnrollStartup
         }
 
         services.AddMetricsPipeline(ConfigureDb);
+        services.AddHttpClient<HttpMetricsClient>();
         services.AddRepositoriesAndSagas<SummaryDbContext>(
             ConfigureDb,
             cfg => cfg.UsingInMemory((context, c) => { }));

--- a/MetricsPipeline.Tests/Steps/DemoApiSteps.cs
+++ b/MetricsPipeline.Tests/Steps/DemoApiSteps.cs
@@ -1,0 +1,48 @@
+using Reqnroll;
+using MetricsPipeline.Infrastructure;
+using System.Net.Http;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FluentAssertions;
+
+[Binding]
+[Scope(Feature="DemoApiIntegration")]
+public class DemoApiSteps
+{
+    private readonly HttpMetricsClient _client;
+    private IReadOnlyList<double>? _result;
+    private Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<MetricsPipeline.DemoApi.Program>? _factory;
+
+    public DemoApiSteps(HttpMetricsClient client)
+    {
+        _client = client;
+    }
+
+    [Given("the demo API is running")]
+    public void GivenApiRunning()
+    {
+        _factory = new Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<MetricsPipeline.DemoApi.Program>();
+    }
+    [When(@"the http client requests ""(.*)"" using GET")]
+
+    public async Task WhenClientRequests(string uri)
+    {
+        if (_factory != null)
+        {
+            var client = _factory.CreateClient();
+            var metricsClient = new HttpMetricsClient(client);
+            _result = await metricsClient.SendAsync<double>(HttpMethod.Get, uri);
+        }
+        else
+        {
+            _result = await _client.SendAsync<double>(HttpMethod.Get, uri);
+        }
+    }
+
+    [Then(@"the response list should contain (\d+) items")]
+    public void ThenListCount(int count)
+    {
+        _result.Should().NotBeNull();
+        _result!.Count.Should().Be(count);
+    }
+}

--- a/MetricsPipeline.Tests/Steps/GenericValidationSteps.cs
+++ b/MetricsPipeline.Tests/Steps/GenericValidationSteps.cs
@@ -36,11 +36,16 @@ public class GenericValidationSteps
             _items.Add(new ValueItem { Amount = double.Parse(row[0]) });
     }
 
-    [When("the list is validated by (summing|averaging) Amount")]
-    public void WhenValidated(string method)
+    [When("the list is validated by summing Amount")]
+    public void WhenValidatedSum()
     {
-        var strategy = method == "summing" ? SummaryStrategy.Sum : SummaryStrategy.Average;
-        _result = _val.IsWithinThreshold(_items, i => i.Amount, strategy, _last, _delta);
+        _result = _val.IsWithinThreshold(_items, i => i.Amount, SummaryStrategy.Sum, _last, _delta);
+    }
+
+    [When("the list is validated by averaging Amount")]
+    public void WhenValidatedAverage()
+    {
+        _result = _val.IsWithinThreshold(_items, i => i.Amount, SummaryStrategy.Average, _last, _delta);
     }
 
     [Then("the summary should be marked as (.*)")]

--- a/MetricsPipeline.sln
+++ b/MetricsPipeline.sln
@@ -9,6 +9,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MetricsPipeline.Tests", "Me
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MetricsPipeline.Console", "MetricsPipeline.Console\MetricsPipeline.Console.csproj", "{C777FE8B-9233-423F-9C68-780D6ED8DC07}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MetricsPipeline.AppHost", "MetricsPipeline.AppHost\MetricsPipeline.AppHost.csproj", "{9E2F9A8F-747C-44E7-BFF2-F333AB013D00}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MetricsPipeline.DemoApi", "MetricsPipeline.DemoApi\MetricsPipeline.DemoApi.csproj", "{3CBF5FD1-4215-45BB-AC97-BDA37A89BB6C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -55,6 +59,30 @@ Global
 		{C777FE8B-9233-423F-9C68-780D6ED8DC07}.Release|x64.Build.0 = Release|Any CPU
 		{C777FE8B-9233-423F-9C68-780D6ED8DC07}.Release|x86.ActiveCfg = Release|Any CPU
 		{C777FE8B-9233-423F-9C68-780D6ED8DC07}.Release|x86.Build.0 = Release|Any CPU
+		{9E2F9A8F-747C-44E7-BFF2-F333AB013D00}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9E2F9A8F-747C-44E7-BFF2-F333AB013D00}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9E2F9A8F-747C-44E7-BFF2-F333AB013D00}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9E2F9A8F-747C-44E7-BFF2-F333AB013D00}.Debug|x64.Build.0 = Debug|Any CPU
+		{9E2F9A8F-747C-44E7-BFF2-F333AB013D00}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9E2F9A8F-747C-44E7-BFF2-F333AB013D00}.Debug|x86.Build.0 = Debug|Any CPU
+		{9E2F9A8F-747C-44E7-BFF2-F333AB013D00}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9E2F9A8F-747C-44E7-BFF2-F333AB013D00}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9E2F9A8F-747C-44E7-BFF2-F333AB013D00}.Release|x64.ActiveCfg = Release|Any CPU
+		{9E2F9A8F-747C-44E7-BFF2-F333AB013D00}.Release|x64.Build.0 = Release|Any CPU
+		{9E2F9A8F-747C-44E7-BFF2-F333AB013D00}.Release|x86.ActiveCfg = Release|Any CPU
+		{9E2F9A8F-747C-44E7-BFF2-F333AB013D00}.Release|x86.Build.0 = Release|Any CPU
+		{3CBF5FD1-4215-45BB-AC97-BDA37A89BB6C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3CBF5FD1-4215-45BB-AC97-BDA37A89BB6C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3CBF5FD1-4215-45BB-AC97-BDA37A89BB6C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{3CBF5FD1-4215-45BB-AC97-BDA37A89BB6C}.Debug|x64.Build.0 = Debug|Any CPU
+		{3CBF5FD1-4215-45BB-AC97-BDA37A89BB6C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{3CBF5FD1-4215-45BB-AC97-BDA37A89BB6C}.Debug|x86.Build.0 = Debug|Any CPU
+		{3CBF5FD1-4215-45BB-AC97-BDA37A89BB6C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3CBF5FD1-4215-45BB-AC97-BDA37A89BB6C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3CBF5FD1-4215-45BB-AC97-BDA37A89BB6C}.Release|x64.ActiveCfg = Release|Any CPU
+		{3CBF5FD1-4215-45BB-AC97-BDA37A89BB6C}.Release|x64.Build.0 = Release|Any CPU
+		{3CBF5FD1-4215-45BB-AC97-BDA37A89BB6C}.Release|x86.ActiveCfg = Release|Any CPU
+		{3CBF5FD1-4215-45BB-AC97-BDA37A89BB6C}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ This project demonstrates a simple yet fully testable metrics processing pipelin
 | **MetricsPipeline.Core** | Domain interfaces, pipeline orchestration logic and Entity Framework Core infrastructure. |
 | **MetricsPipeline.Console** | Console application that wires the pipeline together and runs a sample workflow. |
 | **MetricsPipeline.Tests** | xUnit/Reqnroll test suite validating each stage and the end-to-end flow. |
+| **MetricsPipeline.DemoApi** | Minimal API returning sample metrics for the worker to consume. |
+| **MetricsPipeline.AppHost** | Dotnet Aspire host that runs the demo API and worker together. |
 
 ## Getting Started
 
@@ -21,11 +23,15 @@ This project demonstrates a simple yet fully testable metrics processing pipelin
    dotnet ef migrations add <name> --project MetricsPipeline.Core
    ```
    Updating the database can then be performed manually when required.
-3. **Run the sample console application**
+3. **Run the Aspire host**
+   ```bash
+   dotnet run --project MetricsPipeline.AppHost
+   ```
+4. **Run the sample console application alone**
    ```bash
    dotnet run --project MetricsPipeline.Console
    ```
-4. **Execute the tests**
+5. **Execute the tests**
    ```bash
    dotnet test
    ```
@@ -91,6 +97,8 @@ When no prior summary exists the orchestrator now treats the run as valid regard
 
 The worker can be customised by supplying an alternative gather method name when invoking the orchestrator. A single worker can host several pipelines targeting different data types so multiple gather methods may run side by side. Each pipeline has its own threshold and summarisation strategy, making it simple to plug the library into new domains without rewriting the worker service.
 
+The `MetricsPipeline.DemoApi` project exposes a minimal `/metrics` endpoint returning sample values. A reusable `HttpMetricsClient` abstracts `HttpClient` so the worker can fetch data from any URI using any HTTP method and deserialize it into a list of typed objects. When running under `MetricsPipeline.AppHost` the console worker automatically calls the demo API through this client.
+
 ## Database Migrations
 
 Entity Framework Core migrations are included with the project. Ensure the `dotnet-ef` tool is installed:
@@ -116,6 +124,8 @@ services.AddScoped<IGatherService, MyGatherService>();
 ```
 
 Additional summarisation strategies can be registered in the same way to tailor the pipeline to new data sources.
+
+You can also reuse `HttpMetricsClient` in your own services to call REST endpoints by specifying the HTTP method and target URI. The client returns a strongly typed list so it works with any DTO shape.
 
 You can also extend the validation logic by implementing `IValidationService`. The default implementation can summarise any `List<T>` by projecting a property with a LINQ expression. Register your custom service before running the worker to apply domain-specific rules or alternative summarisation logic.
 


### PR DESCRIPTION
## Summary
- fix generic validation step definitions
- implement demo API returning metric data
- add generic `HttpMetricsClient` and `HttpGatherService`
- register HTTP client in console app and use demo API
- create Aspire app host to run worker and API together
- document new projects and usage in README
- add demo API integration BDD test

## Testing
- `dotnet build`
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_68506ba441a08330b298c004694b65c2