### PR TITLE
Configure the http client to use service discovery

### DIFF
--- a/MetricsPipeline.AppHost/Program.cs
+++ b/MetricsPipeline.AppHost/Program.cs
@@ -2,7 +2,10 @@ using Aspire.Hosting;
 
 var builder = DistributedApplication.CreateBuilder(args);
 
-builder.AddProject("demoapi", "../MetricsPipeline.DemoApi/MetricsPipeline.DemoApi.csproj");
-builder.AddProject("worker", "../MetricsPipeline.Console/MetricsPipeline.Console.csproj");
+var demo = builder.AddProject("demoapi", "../MetricsPipeline.DemoApi/MetricsPipeline.DemoApi.csproj")
+    .WithHttpEndpoint();
+
+builder.AddProject("worker", "../MetricsPipeline.Console/MetricsPipeline.Console.csproj")
+    .WithReference(demo);
 
 builder.Build().Run();

--- a/MetricsPipeline.Console/PipelineWorker.cs
+++ b/MetricsPipeline.Console/PipelineWorker.cs
@@ -35,7 +35,7 @@ public class PipelineWorker : BackgroundService
         await RunStageAsync(TaskStage.Gather, stoppingToken);
         await RunStageAsync(TaskStage.Validate, stoppingToken);
 
-        var source = new Uri("http://localhost:5000/metrics");
+        var source = new Uri("/metrics", UriKind.Relative);
         var result = await _orchestrator.ExecuteAsync("demo", source, SummaryStrategy.Average, 5.0, stoppingToken);
 
         await RunStageAsync(result.IsSuccess ? TaskStage.Commit : TaskStage.Revert, stoppingToken);
@@ -46,7 +46,7 @@ public class PipelineWorker : BackgroundService
         switch (stage)
         {
             case TaskStage.Gather:
-                var gatherResult = await _gather.FetchMetricsAsync(new Uri("http://localhost:5000/metrics"), ct);
+                var gatherResult = await _gather.FetchMetricsAsync(new Uri("/metrics", UriKind.Relative), ct);
                 _gathered = gatherResult.IsSuccess ? gatherResult.Value : Array.Empty<double>();
                 _executed.Add("Gathered");
                 Console.WriteLine("Gathered");

--- a/MetricsPipeline.Console/Program.cs
+++ b/MetricsPipeline.Console/Program.cs
@@ -7,12 +7,17 @@ using MetricsPipeline.Core;
 using Microsoft.Extensions.DependencyInjection;
 
 var host = Host.CreateDefaultBuilder(args)
-    .ConfigureServices(services =>
+    .ConfigureServices((context, services) =>
     {
         services.AddMetricsPipeline(o => o.UseInMemoryDatabase("demo"));
         services.AddHttpClient<HttpMetricsClient>(c =>
         {
-            c.BaseAddress = new Uri("http://localhost:5000");
+            var discovered = context.Configuration["services:demoapi:0"] ??
+                              context.Configuration["services:demoapi"];
+            if (!string.IsNullOrEmpty(discovered))
+            {
+                c.BaseAddress = new Uri(discovered);
+            }
         });
         services.AddTransient<IGatherService, HttpGatherService>();
         services.AddHostedService<PipelineWorker>();

--- a/MetricsPipeline.Core/Infrastructure/HttpMetricsClient.cs
+++ b/MetricsPipeline.Core/Infrastructure/HttpMetricsClient.cs
@@ -9,6 +9,11 @@ public class HttpMetricsClient
 {
     private readonly HttpClient _client;
 
+    /// <summary>
+    /// Gets the base address configured on the underlying <see cref="HttpClient"/>.
+    /// </summary>
+    public Uri? BaseAddress => _client.BaseAddress;
+
     public HttpMetricsClient(HttpClient client)
     {
         _client = client;

--- a/MetricsPipeline.Tests/Features/4600-service-discovery-httpclient.feature
+++ b/MetricsPipeline.Tests/Features/4600-service-discovery-httpclient.feature
@@ -1,0 +1,7 @@
+Feature: HttpClientServiceDiscovery
+  Ensure HttpMetricsClient picks up the base address from service discovery
+
+  Scenario: Resolve base address via environment variable
+    Given service discovery variable is "http://example.com"
+    When the metrics client is created
+    Then the metrics client base address should be "http://example.com/"

--- a/MetricsPipeline.Tests/Steps/HttpClientDiscoverySteps.cs
+++ b/MetricsPipeline.Tests/Steps/HttpClientDiscoverySteps.cs
@@ -1,0 +1,45 @@
+using System;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using MetricsPipeline.Infrastructure;
+using Reqnroll;
+
+[Binding]
+[Scope(Feature="HttpClientServiceDiscovery")]
+public class HttpClientDiscoverySteps
+{
+    private HttpMetricsClient? _client;
+
+    [Given("service discovery variable is \"(.*)\"")]
+    public void GivenServiceDiscoveryVariable(string uri)
+    {
+        Environment.SetEnvironmentVariable("services__demoapi__0", uri);
+    }
+
+    [When("the metrics client is created")]
+    public void WhenClientCreated()
+    {
+        var host = Host.CreateDefaultBuilder()
+            .ConfigureServices((context, services) =>
+            {
+                services.AddHttpClient<HttpMetricsClient>(c =>
+                {
+                    var baseAddress = context.Configuration["services:demoapi:0"];
+                    if (!string.IsNullOrEmpty(baseAddress))
+                    {
+                        c.BaseAddress = new Uri(baseAddress);
+                    }
+                });
+            })
+            .Build();
+        _client = host.Services.GetRequiredService<HttpMetricsClient>();
+    }
+
+    [Then("the metrics client base address should be \"(.*)\"")]
+    public void ThenBaseAddress(string expected)
+    {
+        _client.Should().NotBeNull();
+        _client!.BaseAddress!.ToString().Should().Be(expected);
+    }
+}


### PR DESCRIPTION
## Summary
- inject discovered base address into `HttpMetricsClient`
- use relative metrics endpoint in `PipelineWorker`
- expose `BaseAddress` from `HttpMetricsClient`
- add BDD test for service discovery
- document service discovery and client details
- configure the Aspire host to link worker and API via `.WithReference`

## Testing
- `dotnet test MetricsPipeline.sln`

------
https://chatgpt.com/codex/tasks/task_e_685075d9ad408330bcef61ab2d94925e