### PR TITLE
Add InvalidGatherMethod scenario

### DIFF
--- a/MetricsPipeline.Tests/Features/3430-invalid-gather-method.feature
+++ b/MetricsPipeline.Tests/Features/3430-invalid-gather-method.feature
@@ -1,0 +1,8 @@
+Feature: InvalidGatherMethodName
+  Validate behaviour when an unknown gather method is specified.
+
+  Scenario: Execute pipeline using unknown gather method
+    Given the gather method is "NonExistentMethod"
+    When the orchestrator executes with an invalid gather method
+    Then the orchestrator should return an InvalidGatherMethod error
+    And no summary should be computed or committed

--- a/MetricsPipeline.Tests/Steps/InvalidGatherMethodSteps.cs
+++ b/MetricsPipeline.Tests/Steps/InvalidGatherMethodSteps.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using MetricsPipeline.Core;
+using Reqnroll;
+
+namespace MetricsPipeline.Tests.Steps;
+
+[Binding]
+[Scope(Feature = "InvalidGatherMethodName")]
+public class InvalidGatherMethodSteps
+{
+    private readonly IPipelineOrchestrator _orchestrator;
+    private PipelineResult<PipelineState>? _result;
+
+    public InvalidGatherMethodSteps(IPipelineOrchestrator orchestrator)
+    {
+        _orchestrator = orchestrator;
+    }
+
+    [When("the orchestrator executes with an invalid gather method")]
+    public async Task WhenOrchestratorExecutesInvalid()
+    {
+        _result = await _orchestrator.ExecuteAsync(
+            "default",
+            new Uri("https://api.example.com/data"),
+            SummaryStrategy.Average,
+            5.0,
+            CancellationToken.None,
+            "NonExistentMethod");
+    }
+
+    [Then("the orchestrator should return an InvalidGatherMethod error")]
+    public void ThenInvalidGatherMethodError()
+    {
+        _result!.IsSuccess.Should().BeFalse();
+        _result.Error.Should().Be("InvalidGatherMethod");
+    }
+
+    [Then("no summary should be computed or committed")]
+    public void ThenNoSummary()
+    {
+        _result!.IsSuccess.Should().BeFalse();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -99,7 +99,17 @@ When no prior summary exists the orchestrator now treats the run as valid regard
 
 `MetricsPipeline.Console` registers the pipeline services with a dependency injection container and runs `PipelineWorker`, a hosted service that executes the pipeline once at startup. The worker output demonstrates how each stage is called and whether the final summary is persisted or discarded.
 
-The worker can be customised by supplying an alternative gather method name when invoking the orchestrator. A single worker can host several pipelines targeting different data types so multiple gather methods may run side by side. Each pipeline has its own threshold and summarisation strategy, making it simple to plug the library into new domains without rewriting the worker service.
+The worker can be customised by supplying an alternative gather method name when invoking the orchestrator. A single worker can host several pipelines targeting different data types so multiple gather methods may run side by side. Each pipeline has its own threshold and summarisation strategy, making it simple to plug the library into new domains without rewriting the worker service. The method name is passed via the `gatherMethodName` parameter:
+
+```csharp
+await orchestrator.ExecuteAsync(
+    "cpu", source, SummaryStrategy.Average, 10.0, gatherMethodName: "CustomGatherAsync");
+```
+
+- The orchestrator verifies that the supplied method exists on the gather service.
+- Missing methods or incorrect return types cause an `InvalidGatherMethod` error.
+- The test suite now includes an *InvalidGatherMethodName* scenario exercising this path.
+- Execute `dotnet test` to run all scenarios including the new one.
 All HTTP calls use relative paths which combine with the discovered service base address, keeping configuration minimal.
 You can inspect `HttpMetricsClient.BaseAddress` at runtime to confirm which endpoint was resolved.
 


### PR DESCRIPTION
## Summary
- add BDD coverage for invalid gather method name
- implement InvalidGatherMethodSteps
- document gatherMethodName parameter and new test

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_685082fe6bec8330a0065470203b8052