### PR TITLE
Fix failing tests and dependency injection

### DIFF
--- a/MetricsPipeline.Core/Infrastructure/DependencyInjection.cs
+++ b/MetricsPipeline.Core/Infrastructure/DependencyInjection.cs
@@ -28,11 +28,11 @@ public static class DependencyInjection
         where TContext : SummaryDbContext
     {
         services.AddDbContext<SummaryDbContext, TContext>(dbCfg);
-        // Use a scoped lifetime for the in-memory gather service so that
-        // the orchestrator and step definitions share the same instance
-        // within a single scenario while avoiding cross-scenario state.
-        services.AddScoped<IGatherService, InMemoryGatherService>();
-        services.AddScoped<IWorkerService, InMemoryGatherService>();
+        // Use a single scoped instance of the gather service so both IGatherService
+        // and IWorkerService resolve to the same object within a scenario.
+        services.AddScoped<InMemoryGatherService>();
+        services.AddScoped<IGatherService>(sp => sp.GetRequiredService<InMemoryGatherService>());
+        services.AddScoped<IWorkerService>(sp => sp.GetRequiredService<InMemoryGatherService>());
         services.AddTransient<ISummarizationService, InMemorySummarizationService>();
         services.AddTransient<IValidationService, ThresholdValidationService>();
         services.AddTransient<ICommitService, EfCommitService>();

--- a/MetricsPipeline.Core/Infrastructure/PipelineOrchestrator.cs
+++ b/MetricsPipeline.Core/Infrastructure/PipelineOrchestrator.cs
@@ -41,10 +41,12 @@ public class PipelineOrchestrator : IPipelineOrchestrator
 
         var method = _worker.GetType().GetMethod(workerMethod);
         if (method == null)
-            return PipelineResult<PipelineState<T>>.Failure("InvalidWorkerMethod");
+            return PipelineResult<PipelineState<T>>.Failure("InvalidGatherMethod");
+        if (method.IsGenericMethodDefinition)
+            method = method.MakeGenericMethod(typeof(T));
         var fetchTask = method.Invoke(_worker, new object[] { source, ct }) as Task<PipelineResult<IReadOnlyList<T>>>;
         if (fetchTask == null)
-            return PipelineResult<PipelineState<T>>.Failure("InvalidWorkerMethod");
+            return PipelineResult<PipelineState<T>>.Failure("InvalidGatherMethod");
         var fetch = await fetchTask;
         if (!fetch.IsSuccess) return PipelineResult<PipelineState<T>>.Failure(fetch.Error!);
         var values = fetch.Value!.Select(selector).ToList();

--- a/MetricsPipeline.Tests/PipelineStateTests.cs
+++ b/MetricsPipeline.Tests/PipelineStateTests.cs
@@ -10,11 +10,11 @@ public class PipelineStateTests
     {
         var ts = DateTime.UtcNow;
         var metrics = new double[] { 1.0, 2.0 };
-        var state = new PipelineState("pipe", new Uri("https://example.com"), metrics, 3.0, 2.0, 1.5, ts);
+        var state = new PipelineState<double>("pipe", new Uri("https://example.com"), metrics, 3.0, 2.0, 1.5, ts);
 
         Assert.Equal("pipe", state.PipelineName);
         Assert.Equal(new Uri("https://example.com"), state.SourceEndpoint);
-        Assert.True(metrics.SequenceEqual(state.RawMetrics));
+        Assert.True(metrics.SequenceEqual(state.RawItems));
         Assert.Equal(3.0, state.Summary);
         Assert.Equal(2.0, state.LastCommittedSummary);
         Assert.Equal(1.5, state.AcceptableDelta);

--- a/MetricsPipeline.Tests/Steps/GenericWorkerServiceSteps.cs
+++ b/MetricsPipeline.Tests/Steps/GenericWorkerServiceSteps.cs
@@ -23,7 +23,7 @@ public class GenericWorkerServiceSteps
         _worker = (InMemoryGatherService)worker;
     }
 
-    [Given(@"the API at \"(.*)\" returns:")]
+    [Given(@"the API at ""(.*)"" returns:")]
     public void GivenApiReturns(string endpoint, Table table)
     {
         _source = new Uri(endpoint);

--- a/MetricsPipeline.Tests/Steps/InvalidGatherMethodSteps.cs
+++ b/MetricsPipeline.Tests/Steps/InvalidGatherMethodSteps.cs
@@ -12,7 +12,7 @@ namespace MetricsPipeline.Tests.Steps;
 public class InvalidGatherMethodSteps
 {
     private readonly IPipelineOrchestrator _orchestrator;
-    private PipelineResult<PipelineState>? _result;
+    private PipelineResult<PipelineState<double>>? _result;
 
     public InvalidGatherMethodSteps(IPipelineOrchestrator orchestrator)
     {
@@ -22,9 +22,10 @@ public class InvalidGatherMethodSteps
     [When("the orchestrator executes with an invalid gather method")]
     public async Task WhenOrchestratorExecutesInvalid()
     {
-        _result = await _orchestrator.ExecuteAsync(
+        _result = await _orchestrator.ExecuteAsync<double>(
             "default",
             new Uri("https://api.example.com/data"),
+            v => v,
             SummaryStrategy.Average,
             5.0,
             CancellationToken.None,


### PR DESCRIPTION
## Summary
- share InMemoryGatherService instance across interfaces
- fix generic method invocation in orchestrator
- correct typed pipeline tests
- expand worker service test helper
- document DB provider selection and test filtering

## Testing
- `dotnet test MetricsPipeline.sln -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_685188798c1c8330981c68743a1c40b3