### PR TITLE
Simplify worker execution

### DIFF
--- a/MetricsPipeline.Tests/Features/3410-worker-stage-execution.feature
+++ b/MetricsPipeline.Tests/Features/3410-worker-stage-execution.feature
@@ -1,5 +1,5 @@
 Feature: WorkerStageExecution
-  Verify the PipelineWorker executes the correct stages based on the orchestrator result.
+  Verify the PipelineWorker interprets the orchestrator result.
 
   Scenario Outline: Worker handles <Outcome> result
     Given the worker is configured for <Outcome>
@@ -7,6 +7,6 @@ Feature: WorkerStageExecution
     Then the stage results should be "<Stages>"
 
     Examples:
-      | Outcome | Stages                       |
-      | success | Gathered,Validated,Committed |
-      | failure | Gathered,Validated,Reverted  |
+      | Outcome | Stages    |
+      | success | Committed |
+      | failure | Reverted  |

--- a/MetricsPipeline.Tests/Steps/PipelineWorkerSteps.cs
+++ b/MetricsPipeline.Tests/Steps/PipelineWorkerSteps.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
@@ -28,36 +27,10 @@ internal class FakeOrchestrator : IPipelineOrchestrator
     }
 }
 
-// Exposes the protected ExecuteAsync method for testing
-internal class FakeWorkerService : IGatherService, IWorkerService
-{
-    public Task<PipelineResult<IReadOnlyList<double>>> FetchMetricsAsync(Uri source, CancellationToken ct = default)
-        => Task.FromResult(PipelineResult<IReadOnlyList<double>>.Success(new List<double>{1.0,2.0}));
-
-    public Task<PipelineResult<IReadOnlyList<T>>> FetchAsync<T>(Uri source, CancellationToken ct = default)
-    {
-        var data = new List<double> { 1.0, 2.0 };
-        if (typeof(T) == typeof(double))
-            return Task.FromResult(PipelineResult<IReadOnlyList<T>>.Success((IReadOnlyList<T>)(object)data));
-
-        var prop = typeof(T).GetProperty("Value") ?? typeof(T).GetProperty("Amount");
-        if (prop == null || prop.PropertyType != typeof(double))
-            return Task.FromResult(PipelineResult<IReadOnlyList<T>>.Failure("UnsupportedType"));
-
-        var items = data.Select(v => {
-            var inst = Activator.CreateInstance(typeof(T));
-            prop.SetValue(inst, v);
-            return (T)inst!;
-        }).ToList();
-
-        return Task.FromResult(PipelineResult<IReadOnlyList<T>>.Success(items));
-    }
-}
-
 internal class TestWorker : PipelineWorker
 {
     public TestWorker(IPipelineOrchestrator orchestrator)
-        : base(orchestrator, new FakeWorkerService()) { }
+        : base(orchestrator) { }
     public Task RunAsync() => base.ExecuteAsync(CancellationToken.None);
 }
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,16 @@ When no prior summary exists the orchestrator now treats the run as valid regard
 
 ## Console Application
 
-`MetricsPipeline.Console` registers the pipeline services with a dependency injection container and runs `PipelineWorker`, a hosted service defined in the core infrastructure. The worker now depends on the new `IWorkerService` so it can retrieve any DTO type. The output demonstrates how each stage is called and whether the final summary is persisted or discarded.
+`MetricsPipeline.Console` registers the pipeline services with a dependency injection container and runs `PipelineWorker`, a hosted service defined in the core infrastructure. The worker no longer injects `IWorkerService`; it simply calls the orchestrator and writes whether the run was committed or reverted. This keeps the background task lightweight while retaining full reuse of the orchestrator.
+
+```csharp
+var source = new Uri("/metrics", UriKind.Relative);
+var result = await _orchestrator.ExecuteAsync<MetricDto>(
+    "demo", source, x => x.Value, SummaryStrategy.Average, 5.0, ct);
+Console.WriteLine(result.IsSuccess ? "Committed" : "Reverted");
+```
+
+The worker exposes an `ExecutedStages` list which now contains a single entry representing the final outcome. Success adds `Committed` while failure adds `Reverted`.
 
 ### Running Multiple Pipelines
 
@@ -134,6 +143,7 @@ await _orchestrator.ExecuteAsync<MetricDto>("demo-alt", source, x => x.Value, Su
 ```
 
 Each call to `ExecuteAsync` selects the worker method by name allowing multiple pipelines to reuse the same orchestrator instance.
+Different thresholds and strategies can be applied per pipeline so the same worker can handle diverse datasets.
 
 All HTTP calls use relative paths which combine with the discovered service base address, keeping configuration minimal. You can inspect `HttpMetricsClient.BaseAddress` at runtime to confirm which endpoint was resolved so you know exactly which service the worker discovered. The worker service reuses `HttpMetricsClient` so any DTO can be downloaded and summarised without additional boilerplate.
 
@@ -166,7 +176,7 @@ Implement your own `IWorkerService` to pull data from alternative sources. Regis
 ```csharp
 services.AddScoped<IWorkerService, MyWorkerService>();
 ```
-When using the built-in `InMemoryGatherService`, both interfaces resolve to the same scoped instance so registrations should follow the same pattern.
+When using the built-in `InMemoryGatherService`, both interfaces resolve to the same scoped instance so registrations should follow the same pattern. Because the worker now delegates entirely to the orchestrator you can swap gather services without modifying the hosted service.
 
 You can also reuse `HttpMetricsClient` in your own services to call REST endpoints by specifying the HTTP method and target URI. The client returns a strongly typed list so it works with any DTO shape. When a `services__<name>__0` environment variable is present the client automatically sets its base address, enabling simple service discovery between projects. When hosting multiple projects together you can add them in `MetricsPipeline.AppHost` and call `.WithReference()` so Aspire configures the discovery variables for you.
 
@@ -186,6 +196,7 @@ Register your custom service before running the worker to apply alternative vali
 - Committing or discarding based on validation outcome
 - Repository and unit-of-work behaviour
 - Service discovery of the demo API via environment variables
+- Interpreting the final worker message to confirm the pipeline outcome
 
 Running `dotnet test` executes all scenarios and the supporting unit tests. Database migrations only need to be applied when entity models change:
 


### PR DESCRIPTION
## Summary
- streamline `PipelineWorker` to delegate execution to orchestrator
- drop redundant gather/validate stages
- update worker feature and steps for new behaviour
- revise README to document simplified worker design

## Testing
- `dotnet test MetricsPipeline.sln --no-build`

------
https://chatgpt.com/codex/tasks/task_e_6851a54eacf48330875dd5989ca66ee6