### PR TITLE
Simplify worker configuration

### DIFF
--- a/MetricsPipeline.Core/MetricsPipeline.Core.csproj
+++ b/MetricsPipeline.Core/MetricsPipeline.Core.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.6" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.6" />
     <PackageReference Include="MassTransit" Version="8.4.1" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.6" />
   </ItemGroup>
 
 

--- a/MetricsPipeline.Tests/Steps/MetricsPipelineOptionsSteps.cs
+++ b/MetricsPipeline.Tests/Steps/MetricsPipelineOptionsSteps.cs
@@ -4,6 +4,7 @@ using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using MetricsPipeline.Infrastructure;
+using MetricsPipeline.Core;
 using Microsoft.EntityFrameworkCore;
 using Reqnroll;
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,13 @@ Console.WriteLine(result.IsSuccess ? "Committed" : "Reverted");
 ```
 
 The worker exposes an `ExecutedStages` list which now contains a single entry representing the final outcome. Success adds `Committed` while failure adds `Reverted`.
+Additional notes:
+
+* The previous `RunStageAsync` helper was removed. `ExecuteAsync` simply delegates to the orchestrator and logs the final state.
+* You can tweak the summarisation strategy and threshold on each call without modifying the worker code.
+* `PipelineResult.IsSuccess` indicates whether the summary was committed (`true`) or reverted (`false`).
+* Custom discard handlers can observe failed results for auditing or alerting purposes.
+* `MetricsPipelineOptions` exposes flags to register the worker and HTTP client so configuration remains minimal.
 
 
 ### Running Multiple Pipelines


### PR DESCRIPTION
## Summary
- reference `Microsoft.Extensions.Http` so AddHttpClient extension resolves
- update MetricsPipelineOptionsSteps with missing namespace
- clarify PipelineWorker explanation in README

## Testing
- `dotnet build MetricsPipeline.sln --no-restore -c Release`
- `dotnet test MetricsPipeline.Tests/MetricsPipeline.Tests.csproj --no-build` *(fails: The argument ... is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_6851ac251cf88330ab85a05f87cc6344