### PR TITLE
Add WorkerMode setting

### DIFF
--- a/MetricsPipeline.Console/Program.cs
+++ b/MetricsPipeline.Console/Program.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.Extensions.Configuration;
 using MetricsPipeline.Infrastructure;
+using MetricsPipeline.Core;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.DependencyInjection;
@@ -14,7 +15,7 @@ var host = Host.CreateDefaultBuilder(args)
             opts =>
             {
                 opts.AddWorker = true;
-                opts.UseHttpWorker = true;
+                opts.WorkerMode = WorkerMode.Http;
                 opts.ConfigureClient = (sp, c) =>
                 {
                     var cfg = sp.GetRequiredService<IConfiguration>();

--- a/MetricsPipeline.Core/Core/Contracts.cs
+++ b/MetricsPipeline.Core/Core/Contracts.cs
@@ -6,6 +6,11 @@ namespace MetricsPipeline.Core
     public enum SummaryStrategy { Average, Sum, Count }
 
     /// <summary>
+    /// Mode controlling how metrics are gathered and processed.
+    /// </summary>
+    public enum WorkerMode { InMemory, Http }
+
+    /// <summary>
     /// Service responsible for retrieving raw metric values.
     /// </summary>
     public interface IGatherService

--- a/MetricsPipeline.Core/Infrastructure/DependencyInjection.cs
+++ b/MetricsPipeline.Core/Infrastructure/DependencyInjection.cs
@@ -35,7 +35,7 @@ public static class DependencyInjection
 
         services.AddDbContext<SummaryDbContext, TContext>(dbCfg);
 
-        if (options.UseHttpWorker)
+        if (options.WorkerMode == WorkerMode.Http)
         {
             RegisterHttpClient(services, options);
             services.AddTransient<IGatherService, HttpGatherService>();

--- a/MetricsPipeline.Core/Infrastructure/MetricsPipelineOptions.cs
+++ b/MetricsPipeline.Core/Infrastructure/MetricsPipelineOptions.cs
@@ -1,6 +1,7 @@
 namespace MetricsPipeline.Infrastructure;
 using System;
 using System.Net.Http;
+using MetricsPipeline.Core;
 
 /// <summary>
 /// Options controlling additional registrations when calling <see cref="DependencyInjection.AddMetricsPipeline"/>.
@@ -13,9 +14,10 @@ public class MetricsPipelineOptions
     public bool AddWorker { get; set; }
 
     /// <summary>
-    /// Registers <see cref="HttpMetricsClient"/>, <see cref="HttpGatherService"/>, and <see cref="HttpWorkerService"/> when true.
+    /// Determines which gather and worker services are registered.
+    /// Defaults to <see cref="WorkerMode.InMemory"/>.
     /// </summary>
-    public bool UseHttpWorker { get; set; }
+    public WorkerMode WorkerMode { get; set; } = WorkerMode.InMemory;
 
     /// <summary>
     /// Registers <see cref="HttpMetricsClient"/> without altering the gather service.

--- a/MetricsPipeline.Tests/Features/4610-add-metricspipeline-options.feature
+++ b/MetricsPipeline.Tests/Features/4610-add-metricspipeline-options.feature
@@ -9,6 +9,10 @@ Feature: MetricsPipelineOptions
     When the pipeline is added with HttpClient
     Then the service provider should contain HttpMetricsClient
 
-  Scenario: Register HTTP worker services
+  Scenario: Set worker mode to Http
     When the pipeline is added with HTTP worker
     Then IGatherService should be HttpGatherService
+
+  Scenario: Default worker mode is InMemory
+    When the pipeline is added with default worker mode
+    Then IGatherService should be InMemoryGatherService

--- a/MetricsPipeline.Tests/Steps/HttpClientDiscoverySteps.cs
+++ b/MetricsPipeline.Tests/Steps/HttpClientDiscoverySteps.cs
@@ -2,6 +2,8 @@ using System;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.EntityFrameworkCore;
 using MetricsPipeline.Infrastructure;
 using Reqnroll;
 

--- a/MetricsPipeline.Tests/Steps/MetricsPipelineOptionsSteps.cs
+++ b/MetricsPipeline.Tests/Steps/MetricsPipelineOptionsSteps.cs
@@ -42,7 +42,16 @@ public class MetricsPipelineOptionsSteps
         var services = new ServiceCollection();
         services.AddMetricsPipeline(
             o => o.UseInMemoryDatabase(Guid.NewGuid().ToString()),
-            opts => opts.UseHttpWorker = true);
+            opts => opts.WorkerMode = WorkerMode.Http);
+        _provider = services.BuildServiceProvider();
+    }
+
+    [When("the pipeline is added with default worker mode")]
+    public void WhenAddedDefaultWorker()
+    {
+        var services = new ServiceCollection();
+        services.AddMetricsPipeline(
+            o => o.UseInMemoryDatabase(Guid.NewGuid().ToString()));
         _provider = services.BuildServiceProvider();
     }
 
@@ -64,5 +73,12 @@ public class MetricsPipelineOptionsSteps
     {
         _provider.GetService<IGatherService>().Should().BeOfType<HttpGatherService>();
         _provider.GetService<IWorkerService>().Should().BeOfType<HttpWorkerService>();
+    }
+
+    [Then("IGatherService should be InMemoryGatherService")]
+    public void ThenGatherServiceMemory()
+    {
+        _provider.GetService<IGatherService>().Should().BeOfType<InMemoryGatherService>();
+        _provider.GetService<IWorkerService>().Should().BeOfType<InMemoryGatherService>();
     }
 }

--- a/README.md
+++ b/README.md
@@ -66,12 +66,26 @@ This project demonstrates a simple yet fully testable metrics processing pipelin
    `AddMetricsPipeline` can now register the hosted worker and HTTP client automatically when configured.
 13. **Enable the worker via options**
    Pass `opts.AddWorker = true` when calling `AddMetricsPipeline` to run `PipelineWorker` as a background service.
-14. **Register the HTTP client**
+14. **Choose a worker mode**
+   Set `opts.WorkerMode = WorkerMode.Http` to enable the HTTP gatherer or leave it as the default `InMemory` mode.
+15. **Register the HTTP client**
    Set `opts.RegisterHttpClient = true` to make `HttpMetricsClient` available for custom services.
-15. **Customise the HTTP client**
+16. **Customise the HTTP client**
    Use `opts.ConfigureClient` to set `BaseAddress` or other settings after service discovery.
-16. **Run tests without restore**
+17. **Run tests without restore**
    Invoke `dotnet test --no-restore --no-build` for faster execution once packages are restored.
+
+Example configuration enabling the HTTP worker:
+
+```csharp
+services.AddMetricsPipeline(
+    o => o.UseInMemoryDatabase("demo"),
+    opts =>
+    {
+        opts.WorkerMode = WorkerMode.Http;
+        opts.RegisterHttpClient = true;
+    });
+```
 The console host fetches a small set of metric values from an in-memory source, summarises them and either commits the result or discards it depending on validation. Each stage writes its status to the console.
 
 ## Architecture Overview
@@ -147,7 +161,7 @@ Additional notes:
 * You can tweak the summarisation strategy and threshold on each call without modifying the worker code.
 * `PipelineResult.IsSuccess` indicates whether the summary was committed (`true`) or reverted (`false`).
 * Custom discard handlers can observe failed results for auditing or alerting purposes.
-* `MetricsPipelineOptions` exposes flags to register the worker and HTTP client so configuration remains minimal.
+* `MetricsPipelineOptions` exposes flags to register the worker and HTTP client so configuration remains minimal. A `WorkerMode` property controls whether metrics are gathered from memory or via HTTP.
 
 
 ### Running Multiple Pipelines


### PR DESCRIPTION
## Summary
- add WorkerMode enum
- register gather services based on WorkerMode
- update pipeline options steps and feature
- document WorkerMode usage in README
- fix missing usings in HttpClientDiscoverySteps

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build --no-restore`


------
https://chatgpt.com/codex/tasks/task_e_6851af979a548330b9659324e04bbe4e