### PR TITLE
Add worker registration tests and docs

### DIFF
--- a/MetricsPipeline.Tests/Features/4620-worker-registration.feature
+++ b/MetricsPipeline.Tests/Features/4620-worker-registration.feature
@@ -1,0 +1,10 @@
+Feature: WorkerRegistration
+  Ensure the pipeline worker can be optionally registered
+
+  Scenario: Worker not registered by default
+    When the pipeline is added with default options
+    Then the service provider should not contain PipelineWorker
+
+  Scenario: Worker registered on request
+    When the pipeline is added with worker enabled
+    Then the service provider should contain PipelineWorker

--- a/MetricsPipeline.Tests/Steps/WorkerRegistrationSteps.cs
+++ b/MetricsPipeline.Tests/Steps/WorkerRegistrationSteps.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Linq;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using MetricsPipeline.Infrastructure;
+using MetricsPipeline.Core;
+using Microsoft.EntityFrameworkCore;
+using Reqnroll;
+
+namespace MetricsPipeline.Tests.Steps;
+
+[Binding]
+[Scope(Feature = "WorkerRegistration")]
+public class WorkerRegistrationSteps
+{
+    private IServiceProvider _provider = null!;
+
+    [When("the pipeline is added with default options")]
+    public void WhenAddedDefaultOptions()
+    {
+        var services = new ServiceCollection();
+        services.AddMetricsPipeline(o => o.UseInMemoryDatabase(Guid.NewGuid().ToString()));
+        _provider = services.BuildServiceProvider();
+    }
+
+    [When("the pipeline is added with worker enabled")]
+    public void WhenAddedWithWorker()
+    {
+        var services = new ServiceCollection();
+        services.AddMetricsPipeline(
+            o => o.UseInMemoryDatabase(Guid.NewGuid().ToString()),
+            opts => opts.AddWorker = true);
+        _provider = services.BuildServiceProvider();
+    }
+
+    [Then("the service provider should not contain PipelineWorker")]
+    public void ThenDoesNotContainWorker()
+    {
+        var hosted = _provider.GetServices<IHostedService>();
+        hosted.Any(h => h is PipelineWorker).Should().BeFalse();
+    }
+
+    [Then("the service provider should contain PipelineWorker")]
+    public void ThenContainsWorker()
+    {
+        var hosted = _provider.GetServices<IHostedService>();
+        hosted.Any(h => h is PipelineWorker).Should().BeTrue();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -87,6 +87,14 @@ services.AddMetricsPipeline(
     });
 ```
 The console host fetches a small set of metric values from an in-memory source, summarises them and either commits the result or discards it depending on validation. Each stage writes its status to the console.
+## Worker Registration and DI Options
+
+- **AddWorker** registers `PipelineWorker` as a hosted service so metrics run in the background.
+- **WorkerMode** selects between `InMemory` and `Http` gatherers.
+- **RegisterHttpClient** makes `HttpMetricsClient` available without changing the gather service.
+- **ConfigureClient** lets you set `HttpClient` properties such as `BaseAddress` after service discovery.
+- **Worker classes** live under `MetricsPipeline.Core/Infrastructure/Workers` for reuse across hosts.
+
 
 ## Architecture Overview
 


### PR DESCRIPTION
## Summary
- add WorkerRegistration feature tests
- implement step definitions for new feature
- document worker location and DI options in README

## Testing
- `dotnet test --no-build --no-restore --verbosity minimal`


------
https://chatgpt.com/codex/tasks/task_e_6851b20664f88330870f5e7b81e1a56d