### PR TITLE
Add summarisation domain interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,8 @@ This repository demonstrates a simple .NET setup with unit and BDD tests.
 - Created SummarisationPlan<T> for computing numeric metrics with threshold rules.
 - Documented ThresholdType enum for raw difference versus percent change checks.
 - Added examples explaining how these domain events support auditing workflows.
+- Created IEntityRepository<T> to publish SaveRequested events when entities are saved.
+- Introduced ISummarisationValidator<T> interface for encapsulating change validation logic.
+- Added ISaveAuditRepository abstraction for storing SaveAudit records.
+- Added ISummarisationPlanStore for retrieving plans by entity type.
+- Documented how these interfaces improve testability of summarisation workflows.

--- a/src/ExampleLib/Domain/IEntityRepository.cs
+++ b/src/ExampleLib/Domain/IEntityRepository.cs
@@ -1,0 +1,14 @@
+using System.Threading.Tasks;
+
+namespace ExampleLib.Domain;
+
+/// <summary>
+/// Repository interface for entity operations. Saving an entity will publish a SaveRequested event.
+/// </summary>
+public interface IEntityRepository<T>
+{
+    /// <summary>
+    /// Saves the entity (publishing a SaveRequested event for validation).
+    /// </summary>
+    Task SaveAsync(string appName, T entity);
+}

--- a/src/ExampleLib/Domain/ISaveAuditRepository.cs
+++ b/src/ExampleLib/Domain/ISaveAuditRepository.cs
@@ -1,0 +1,13 @@
+namespace ExampleLib.Domain;
+
+/// <summary>
+/// Repository for saving and retrieving SaveAudit records for entities.
+/// </summary>
+public interface ISaveAuditRepository
+{
+    /// <summary>Retrieve the latest SaveAudit for a given entity (by type and ID), or null if none exists.</summary>
+    SaveAudit? GetLastAudit(string entityType, string entityId);
+
+    /// <summary>Persist a new SaveAudit record.</summary>
+    void AddAudit(SaveAudit audit);
+}

--- a/src/ExampleLib/Domain/ISummarisationPlanStore.cs
+++ b/src/ExampleLib/Domain/ISummarisationPlanStore.cs
@@ -1,0 +1,10 @@
+namespace ExampleLib.Domain;
+
+/// <summary>
+/// Store for summarisation plans, providing the plan for a given entity type.
+/// </summary>
+public interface ISummarisationPlanStore
+{
+    /// <summary>Retrieve the SummarisationPlan for entity type T.</summary>
+    SummarisationPlan<T> GetPlan<T>();
+}

--- a/src/ExampleLib/Domain/ISummarisationValidator.cs
+++ b/src/ExampleLib/Domain/ISummarisationValidator.cs
@@ -1,0 +1,14 @@
+
+namespace ExampleLib.Domain;
+
+/// <summary>
+/// Validates an entity's save against summarisation rules.
+/// </summary>
+public interface ISummarisationValidator<T>
+{
+    /// <summary>
+    /// Validates the current entity against the previous audit record using the provided summarisation plan.
+    /// Returns true if validation passes (within thresholds), false if the change is out of bounds.
+    /// </summary>
+    bool Validate(T currentEntity, SaveAudit previousAudit, SummarisationPlan<T> plan);
+}


### PR DESCRIPTION
## Summary
- add interfaces for summarisation validation and plan storage
- document interfaces in README
- add abstraction for entity repository

## Testing
- `dotnet test RAGStart.sln --no-build --verbosity normal`

------
https://chatgpt.com/codex/tasks/task_e_6852cd58d7e88330af8ee0438ba1d17c