### PR TITLE
Implement in-memory summarisation stores

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,8 @@ This repository demonstrates a simple .NET setup with unit and BDD tests.
 - Added ISaveAuditRepository abstraction for storing SaveAudit records.
 - Added ISummarisationPlanStore for retrieving plans by entity type.
 - Documented how these interfaces improve testability of summarisation workflows.
+- Implemented InMemorySummarisationPlanStore for registering plans in memory.
+- Added InMemorySaveAuditRepository to track the latest audit per entity.
+- Introduced Infrastructure namespace to organize testing helpers.
+- Created unit tests verifying the new in-memory components.
+- Explained thread-safe dictionaries to allow concurrent event handling.

--- a/src/ExampleLib/Infrastructure/InMemorySaveAuditRepository.cs
+++ b/src/ExampleLib/Infrastructure/InMemorySaveAuditRepository.cs
@@ -1,0 +1,31 @@
+using System.Collections.Concurrent;
+using ExampleLib.Domain;
+
+namespace ExampleLib.Infrastructure;
+
+/// <summary>
+/// In-memory implementation of <see cref="ISaveAuditRepository"/> for testing.
+/// Stores only the latest <see cref="SaveAudit"/> per entity.
+/// </summary>
+public class InMemorySaveAuditRepository : ISaveAuditRepository
+{
+    private readonly ConcurrentDictionary<(string, string), SaveAudit> _audits = new();
+
+    /// <summary>
+    /// Retrieve the most recent audit for an entity or null if none exists.
+    /// </summary>
+    public SaveAudit? GetLastAudit(string entityType, string entityId)
+    {
+        _audits.TryGetValue((entityType, entityId), out var audit);
+        return audit;
+    }
+
+    /// <summary>
+    /// Persist a new audit record for an entity, replacing any existing entry.
+    /// </summary>
+    public void AddAudit(SaveAudit audit)
+    {
+        var key = (audit.EntityType, audit.EntityId);
+        _audits[key] = audit;
+    }
+}

--- a/src/ExampleLib/Infrastructure/InMemorySummarisationPlanStore.cs
+++ b/src/ExampleLib/Infrastructure/InMemorySummarisationPlanStore.cs
@@ -1,0 +1,33 @@
+using System.Collections.Concurrent;
+using ExampleLib.Domain;
+
+namespace ExampleLib.Infrastructure;
+
+/// <summary>
+/// In-memory implementation of <see cref="ISummarisationPlanStore"/> for testing.
+/// </summary>
+public class InMemorySummarisationPlanStore : ISummarisationPlanStore
+{
+    private readonly ConcurrentDictionary<Type, object> _plans = new();
+
+    /// <summary>
+    /// Register a <see cref="SummarisationPlan{T}"/> for a specific entity type.
+    /// </summary>
+    public void AddPlan<T>(SummarisationPlan<T> plan)
+    {
+        _plans[typeof(T)] = plan;
+    }
+
+    /// <summary>
+    /// Retrieve the plan for the specified entity type.
+    /// </summary>
+    /// <exception cref="KeyNotFoundException">Thrown when no plan is registered for <typeparamref name="T"/>.</exception>
+    public SummarisationPlan<T> GetPlan<T>()
+    {
+        if (_plans.TryGetValue(typeof(T), out var obj) && obj is SummarisationPlan<T> plan)
+        {
+            return plan;
+        }
+        throw new KeyNotFoundException($"No SummarisationPlan registered for type {typeof(T).Name}");
+    }
+}

--- a/tests/ExampleLib.Tests/InMemoryStoreTests.cs
+++ b/tests/ExampleLib.Tests/InMemoryStoreTests.cs
@@ -1,0 +1,29 @@
+using ExampleLib.Domain;
+using ExampleLib.Infrastructure;
+
+namespace ExampleLib.Tests;
+
+public class InMemoryStoreTests
+{
+    [Fact]
+    public void PlanStore_AddAndRetrieve_Works()
+    {
+        var store = new InMemorySummarisationPlanStore();
+        var plan = new SummarisationPlan<string>(_ => 1m, ThresholdType.RawDifference, 0);
+        store.AddPlan(plan);
+
+        var result = store.GetPlan<string>();
+        Assert.Equal(plan, result);
+    }
+
+    [Fact]
+    public void SaveAuditRepository_AddAndRetrieve_Works()
+    {
+        var repo = new InMemorySaveAuditRepository();
+        var audit = new SaveAudit { EntityType = "User", EntityId = "1", MetricValue = 5m };
+        repo.AddAudit(audit);
+
+        var result = repo.GetLastAudit("User", "1");
+        Assert.Equal(audit, result);
+    }
+}


### PR DESCRIPTION
## Summary
- add in-memory implementations for audit repository and plan store
- organize new infrastructure classes under ExampleLib.Infrastructure
- test these in-memory components
- document new infrastructure and tests in README

## Testing
- `dotnet test`
- `dotnet test --no-restore --no-build`


------
https://chatgpt.com/codex/tasks/task_e_6852ce766a288330975dd4fe403c19fd