### PR TITLE
Implement summarisation validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,8 @@ This repository demonstrates a simple .NET setup with unit and BDD tests.
 - Introduced Infrastructure namespace to organize testing helpers.
 - Created unit tests verifying the new in-memory components.
 - Explained thread-safe dictionaries to allow concurrent event handling.
+- Implemented SummarisationValidator<T> to enforce metric thresholds.
+- Added xUnit tests covering raw difference and percent change checks.
+- Registered validator and repositories for BDD scenarios.
+- Created BDD feature demonstrating summarisation validation rules.
+- Documented how to configure plans and audit storage for tests.

--- a/features/SummarisationValidator.feature
+++ b/features/SummarisationValidator.feature
@@ -1,0 +1,21 @@
+Feature: Summarisation Validator
+  Scenario: First save with no prior audit is valid
+    Given a summarisation plan using RawDifference threshold 5
+    And no previous audit
+    And the current metric is 10
+    When validating the save
+    Then the validation result should be true
+
+  Scenario: Change within raw threshold is valid
+    Given a summarisation plan using RawDifference threshold 5
+    And a previous audit with metric 10
+    And the current metric is 12
+    When validating the save
+    Then the validation result should be true
+
+  Scenario: Percent change above threshold is invalid
+    Given a summarisation plan using PercentChange threshold 0.1
+    And a previous audit with metric 10
+    And the current metric is 12
+    When validating the save
+    Then the validation result should be false

--- a/src/ExampleLib/Domain/SummarisationValidator.cs
+++ b/src/ExampleLib/Domain/SummarisationValidator.cs
@@ -1,0 +1,50 @@
+using System;
+
+namespace ExampleLib.Domain;
+
+/// <summary>
+/// Default implementation of <see cref="ISummarisationValidator{T}"/>.
+/// Compares the current entity metric with the previous saved metric
+/// according to the rules defined in a <see cref="SummarisationPlan{T}"/>.
+/// </summary>
+public class SummarisationValidator<T> : ISummarisationValidator<T>
+{
+    /// <inheritdoc />
+    public bool Validate(T currentEntity, SaveAudit previousAudit, SummarisationPlan<T> plan)
+    {
+        if (plan == null) throw new ArgumentNullException(nameof(plan));
+        if (currentEntity == null) throw new ArgumentNullException(nameof(currentEntity));
+
+        // Compute current metric value from the entity
+        decimal currentValue = plan.MetricSelector(currentEntity);
+
+        // No previous audit means there is no baseline to compare against
+        if (previousAudit == null)
+        {
+            return true;
+        }
+
+        decimal previousValue = previousAudit.MetricValue;
+
+        switch (plan.ThresholdType)
+        {
+            case ThresholdType.RawDifference:
+                var diff = currentValue - previousValue;
+                return Math.Abs(diff) <= plan.ThresholdValue;
+
+            case ThresholdType.PercentChange:
+                if (previousValue == 0)
+                {
+                    // If previous value was zero, treat any non-zero change as exceeding
+                    return currentValue == 0;
+                }
+
+                var changeFraction = Math.Abs((currentValue - previousValue) / previousValue);
+                return changeFraction <= plan.ThresholdValue;
+
+            default:
+                // Unknown threshold type - treat as valid
+                return true;
+        }
+    }
+}

--- a/tests/ExampleLib.BDDTests/Dependencies.cs
+++ b/tests/ExampleLib.BDDTests/Dependencies.cs
@@ -1,5 +1,7 @@
 using ExampleData;
 using ExampleLib;
+using ExampleLib.Domain;
+using ExampleLib.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Reqnroll;
@@ -19,6 +21,9 @@ public static class Dependencies
         services.AddScoped(typeof(IGenericRepository<>), typeof(EfGenericRepository<>));
         services.AddScoped<IValidationService, ValidationService>();
         services.AddScoped<IUnitOfWork, UnitOfWork<YourDbContext>>();
+        services.AddSingleton(typeof(ISummarisationValidator<>), typeof(SummarisationValidator<>));
+        services.AddSingleton<ISummarisationPlanStore, InMemorySummarisationPlanStore>();
+        services.AddSingleton<ISaveAuditRepository, InMemorySaveAuditRepository>();
         return services;
     }
 }

--- a/tests/ExampleLib.BDDTests/SummarisationValidatorSteps.cs
+++ b/tests/ExampleLib.BDDTests/SummarisationValidatorSteps.cs
@@ -1,0 +1,58 @@
+using ExampleData;
+using ExampleLib.Domain;
+using Reqnroll;
+
+namespace ExampleLib.BDDTests;
+
+[Binding]
+public class SummarisationValidatorSteps
+{
+    private readonly ISummarisationValidator<YourEntity> _validator;
+    private SummarisationPlan<YourEntity>? _plan;
+    private SaveAudit? _previous;
+    private YourEntity _entity = new();
+    private bool _result;
+
+    public SummarisationValidatorSteps(ISummarisationValidator<YourEntity> validator)
+    {
+        _validator = validator;
+    }
+
+    [Given("a summarisation plan using (.*) threshold (.*)")]
+    public void GivenAPlan(string type, decimal threshold)
+    {
+        var t = Enum.Parse<ThresholdType>(type);
+        _plan = new SummarisationPlan<YourEntity>(e => e.Id, t, threshold);
+    }
+
+    [Given("no previous audit")]
+    public void GivenNoPreviousAudit()
+    {
+        _previous = null;
+    }
+
+    [Given("a previous audit with metric (.*)")]
+    public void GivenPreviousAudit(decimal value)
+    {
+        _previous = new SaveAudit { MetricValue = value };
+    }
+
+    [Given("the current metric is (.*)")]
+    public void GivenCurrentMetric(decimal value)
+    {
+        _entity.Id = (int)value;
+    }
+
+    [When("validating the save")]
+    public void WhenValidatingTheSave()
+    {
+        _result = _validator.Validate(_entity, _previous, _plan!);
+    }
+
+    [Then("the validation result should be (true|false)")]
+    public void ThenTheValidationResultShouldBe(bool expected)
+    {
+        if (_result != expected)
+            throw new Exception($"Expected {expected} but was {_result}");
+    }
+}

--- a/tests/ExampleLib.Tests/SummarisationValidatorTests.cs
+++ b/tests/ExampleLib.Tests/SummarisationValidatorTests.cs
@@ -1,0 +1,44 @@
+using ExampleData;
+using ExampleLib.Domain;
+
+namespace ExampleLib.Tests;
+
+public class SummarisationValidatorTests
+{
+    private readonly ISummarisationValidator<YourEntity> _validator = new SummarisationValidator<YourEntity>();
+
+    [Fact]
+    public void NoPreviousAudit_ReturnsTrue()
+    {
+        var plan = new SummarisationPlan<YourEntity>(e => e.Id, ThresholdType.RawDifference, 5);
+        var entity = new YourEntity { Id = 10 };
+
+        var result = _validator.Validate(entity, null, plan);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void RawDifferenceWithinThreshold_ReturnsTrue()
+    {
+        var plan = new SummarisationPlan<YourEntity>(e => e.Id, ThresholdType.RawDifference, 5);
+        var entity = new YourEntity { Id = 12 };
+        var previous = new SaveAudit { MetricValue = 10 };
+
+        var result = _validator.Validate(entity, previous, plan);
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void PercentChangeExceedsThreshold_ReturnsFalse()
+    {
+        var plan = new SummarisationPlan<YourEntity>(e => e.Id, ThresholdType.PercentChange, 0.1m);
+        var entity = new YourEntity { Id = 12 };
+        var previous = new SaveAudit { MetricValue = 10 };
+
+        var result = _validator.Validate(entity, previous, plan);
+
+        Assert.False(result);
+    }
+}


### PR DESCRIPTION
## Summary
- create `SummarisationValidator<T>` to enforce metric thresholds
- update DI setup for BDD tests
- add unit tests for validator logic
- add BDD feature and steps covering validator scenarios
- document new validator in README

## Testing
- `dotnet test RAGStart.sln --no-build -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6852cfa411fc8330954dd9df48ebf451