### PR TITLE
Add SQL Server setup and reflection-based app name

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,17 +55,21 @@ This repository demonstrates a simple .NET setup with unit and BDD tests.
 ## Using the Validation Workflow
 
 1. Reference the **ExampleLib** project from your application.
-2. Call `services.AddSaveValidation<T>()` during startup to register the in-memory repositories, validator and MassTransit consumer.
+2. Call `services.AddExampleDataSqlServer(connectionString)` to register `YourDbContext` with SQL Server and a unit of work implementation.
+3. Call `services.AddSaveValidation<T>()` during startup to register the in-memory repositories, validator and MassTransit consumer.
    ```csharp
+   services.AddExampleDataSqlServer("Server=(localdb)\\mssqllocaldb;Database=Orders;");
    services.AddSaveValidation<Order>(o => o.LineAmounts.Sum(), ThresholdType.PercentChange, 0.5m);
    ```
    The extension configures a default `SummarisationPlan` for `Order` entities. The metric selector, threshold type and value can be overridden.
-3. Resolve `IEntityRepository<T>` and save entities as usual:
+4. Resolve `IEntityRepository<T>` and save entities as usual. The repository will automatically derive the application name using reflection:
    ```csharp
    var repo = provider.GetRequiredService<IEntityRepository<Order>>();
-   await repo.SaveAsync("MyApp", order);
+   await repo.SaveAsync(order);
    ```
-4. Previous results are tracked in `ISaveAuditRepository` so each save is compared against the last audit.
-5. To customize thresholds later, retrieve `ISummarisationPlanStore` and call `AddPlan()` with new values before saving.
+5. Previous results are tracked in `ISaveAuditRepository` so each save is compared against the last audit.
+6. To customize thresholds later, retrieve `ISummarisationPlanStore` and call `AddPlan()` with new values before saving.
 
 See `src/ExampleRunner` for a runnable sample demonstrating these steps.
+
+The projects include XML documentation and are structured so **ExampleLib** can be packed as a NuGet package when needed.

--- a/features/SqlServerConfiguration.feature
+++ b/features/SqlServerConfiguration.feature
@@ -1,0 +1,5 @@
+Feature: SQL Server configuration
+  Scenario: DbContext is registered with SQL Server
+    Given a new service collection
+    When AddExampleDataSqlServer is invoked
+    Then the DbContext should use SqlServer

--- a/src/ExampleData/ExampleData.csproj
+++ b/src/ExampleData/ExampleData.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0-preview.3.24172.13" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.0-preview.3.24172.13" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.0-preview.4.24267.1" />
   </ItemGroup>
 
 </Project>

--- a/src/ExampleData/ServiceCollectionExtensions.cs
+++ b/src/ExampleData/ServiceCollectionExtensions.cs
@@ -1,0 +1,27 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace ExampleData;
+
+/// <summary>
+/// Extension methods for registering ExampleData services.
+/// </summary>
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// Adds <see cref="YourDbContext"/> configured for SQL Server and registers
+    /// supporting services.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="connectionString">The connection string to the SQL Server database.</param>
+    /// <returns>The updated service collection.</returns>
+    public static IServiceCollection AddExampleDataSqlServer(
+        this IServiceCollection services,
+        string connectionString)
+    {
+        services.AddDbContext<YourDbContext>(o => o.UseSqlServer(connectionString));
+        services.AddScoped<IValidationService, ValidationService>();
+        services.AddScoped<IUnitOfWork, UnitOfWork<YourDbContext>>();
+        return services;
+    }
+}

--- a/src/ExampleLib/Domain/IEntityRepository.cs
+++ b/src/ExampleLib/Domain/IEntityRepository.cs
@@ -8,7 +8,9 @@ namespace ExampleLib.Domain;
 public interface IEntityRepository<T>
 {
     /// <summary>
-    /// Saves the entity (publishing a SaveRequested event for validation).
+    /// Saves the entity and publishes a <see cref="SaveRequested{T}"/> event.
     /// </summary>
-    Task SaveAsync(string appName, T entity);
+    /// <param name="entity">The entity to save.</param>
+    /// <param name="appName">Optional application name. When omitted the entry assembly name is used.</param>
+    Task SaveAsync(T entity, string? appName = null);
 }

--- a/src/ExampleLib/Infrastructure/EventPublishingRepository.cs
+++ b/src/ExampleLib/Infrastructure/EventPublishingRepository.cs
@@ -17,8 +17,9 @@ public class EventPublishingRepository<T> : IEntityRepository<T>
     }
 
     /// <inheritdoc />
-    public Task SaveAsync(string appName, T entity)
+    public Task SaveAsync(T entity, string? appName = null)
     {
+        appName ??= Assembly.GetEntryAssembly()?.GetName().Name ?? "UnknownApp";
         var entityId = GetEntityId(entity);
         var saveEvent = new SaveRequested<T>
         {

--- a/src/ExampleRunner/Program.cs
+++ b/src/ExampleRunner/Program.cs
@@ -29,7 +29,7 @@ public class Program
             
             var order = new Order { Id = "ORDER123", LineAmounts = new decimal[] { 100m, 50m } };
             Console.WriteLine($"Saving Order {order.Id} with total = {order.LineAmounts.Sum()}");
-            await repository.SaveAsync("MyApp", order);
+            await repository.SaveAsync(order);
             await Task.Delay(500);
 
             var auditRepo = provider.GetRequiredService<ISaveAuditRepository>();
@@ -39,7 +39,7 @@ public class Program
 
             order.LineAmounts = new decimal[] { 300m, 100m };
             Console.WriteLine($"Saving Order {order.Id} with new total = {order.LineAmounts.Sum()}");
-            await repository.SaveAsync("MyApp", order);
+            await repository.SaveAsync(order);
             await Task.Delay(500);
 
             audit = auditRepo.GetLastAudit(nameof(Order), "ORDER123");

--- a/tests/ExampleLib.BDDTests/EventPublishingRepositorySteps.cs
+++ b/tests/ExampleLib.BDDTests/EventPublishingRepositorySteps.cs
@@ -26,7 +26,7 @@ public class EventPublishingRepositorySteps
     {
         var entity = new YourEntity { Id = 1, Name = "Test" };
         if (_repo != null)
-            await _repo.SaveAsync("App", entity);
+            await _repo.SaveAsync(entity);
     }
 
     [Then("a SaveRequested event should be published")]

--- a/tests/ExampleLib.BDDTests/SqlServerConfigurationSteps.cs
+++ b/tests/ExampleLib.BDDTests/SqlServerConfigurationSteps.cs
@@ -1,0 +1,36 @@
+using ExampleData;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+using Reqnroll;
+using Xunit;
+
+namespace ExampleLib.BDDTests;
+
+[Binding]
+public class SqlServerConfigurationSteps
+{
+    private ServiceCollection? _services;
+    private ServiceProvider? _provider;
+
+    [Given("a new service collection")]
+    public void GivenNewServiceCollection()
+    {
+        _services = new ServiceCollection();
+    }
+
+    [When("AddExampleDataSqlServer is invoked")]
+    public void WhenAddExampleDataSqlServerInvoked()
+    {
+        _services!.AddExampleDataSqlServer("Server=(localdb)\\mssqllocaldb;Database=BDD;Trusted_Connection=True;");
+        _provider = _services.BuildServiceProvider();
+    }
+
+    [Then("the DbContext should use SqlServer")]
+    public void ThenDbContextUsesSqlServer()
+    {
+        var ctx = _provider!.GetRequiredService<YourDbContext>();
+        var ext = ctx.GetService<IDbContextOptions>()
+            .FindExtension<Microsoft.EntityFrameworkCore.SqlServer.Infrastructure.Internal.SqlServerOptionsExtension>();
+        Assert.NotNull(ext);
+    }
+}

--- a/tests/ExampleLib.Tests/EventPublishingRepositoryTests.cs
+++ b/tests/ExampleLib.Tests/EventPublishingRepositoryTests.cs
@@ -18,7 +18,7 @@ public class EventPublishingRepositoryTests
         try
         {
             var entity = new YourEntity { Id = 1, Name = "One" };
-            await repo.SaveAsync("App", entity);
+            await repo.SaveAsync(entity);
 
             Assert.True(await harness.Published.Any<SaveRequested<YourEntity>>());
         }
@@ -43,7 +43,7 @@ public class EventPublishingRepositoryTests
         try
         {
             var entity = new NoIdEntity { Name = "Test" };
-            await repo.SaveAsync("App", entity);
+            await repo.SaveAsync(entity);
 
             Assert.True(await harness.Published.Any<SaveRequested<NoIdEntity>>());
         }

--- a/tests/ExampleLib.Tests/ServiceCollectionExtensionsTests.cs
+++ b/tests/ExampleLib.Tests/ServiceCollectionExtensionsTests.cs
@@ -19,7 +19,7 @@ public class ServiceCollectionExtensionsTests
         try
         {
             var repo = provider.GetRequiredService<IEntityRepository<YourEntity>>();
-            await repo.SaveAsync("App", new YourEntity { Id = 1 });
+            await repo.SaveAsync(new YourEntity { Id = 1 });
             await Task.Delay(200);
             var audits = provider.GetRequiredService<ISaveAuditRepository>();
             var audit = audits.GetLastAudit(nameof(YourEntity), "1");


### PR DESCRIPTION
## Summary
- add AddExampleDataSqlServer helper to wire up EF Core with SQL Server
- use reflection to determine app name in EventPublishingRepository
- update unit tests and BDD steps for the new SaveAsync signature
- provide new BDD scenario for SQL Server configuration
- enhance README with setup instructions for SQL Server

## Testing
- `dotnet test --collect:"XPlat Code Coverage" --no-build --no-restore`
- `dotnet test tests/ExampleLib.BDDTests/ExampleLib.BDDTests.csproj` *(fails: output truncated at restore)*

------
https://chatgpt.com/codex/tasks/task_e_6852dcfb97dc8330b12c02163a00ce66