### PR TITLE
Add Mongo database setup extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,18 @@ Applications can register their DbContext and repositories in one line:
 services.SetupDatabase<YourDbContext>("Server=.;Database=example;Trusted_Connection=True");
 ```
 
+When using MongoDB you can initialize everything in a similar fashion:
+
+```csharp
+services.AddExampleDataMongo("mongodb://localhost:27017", "exampledb");
+```
+
+Alternatively register MongoDB with:
+
+```csharp
+services.SetupMongoDatabase("mongodb://localhost:27017", "exampledb");
+```
+
 MongoDB is supported through a parallel set of classes. Install the driver with:
 
 ```bash
@@ -129,6 +141,17 @@ var database = client.GetDatabase("exampledb");
 var uow = new MongoUnitOfWork(database, new MongoValidationService(database));
 var repo = uow.Repository<YourEntity>();
 ```
+
+The `SetupMongoDatabase` helper returns the same services ready for use:
+
+```csharp
+services.SetupMongoDatabase("mongodb://localhost:27017", "exampledb");
+var repo = services.BuildServiceProvider()
+    .GetRequiredService<IGenericRepository<YourEntity>>();
+```
+
+The helpers `AddExampleDataMongo` and `SetupMongoDatabase` register `MongoClient`,
+`IMongoDatabase`, the validation service and unit of work automatically.
 
 `SetupDatabase` configures the DbContext, validation service and generic repositories. Every repository works with the `Validated` soft delete filter enabled by default.
 

--- a/features/MongoConfiguration.feature
+++ b/features/MongoConfiguration.feature
@@ -1,0 +1,5 @@
+Feature: Mongo configuration
+  Scenario: Mongo database is registered
+    Given a new service collection
+    When AddExampleDataMongo is invoked
+    Then the Mongo database should resolve

--- a/features/SetupMongoDatabase.feature
+++ b/features/SetupMongoDatabase.feature
@@ -1,0 +1,5 @@
+Feature: SetupMongoDatabase Extension
+  Scenario: Registers Mongo unit of work
+    Given a new service collection
+    When SetupMongoDatabase is invoked
+    Then a Mongo unit of work can be resolved

--- a/src/ExampleData/MongoGenericRepository.cs
+++ b/src/ExampleData/MongoGenericRepository.cs
@@ -7,9 +7,9 @@ public class MongoGenericRepository<T> : IGenericRepository<T>
 {
     private readonly IMongoCollection<T> _collection;
 
-    public MongoGenericRepository(IMongoCollection<T> collection)
+    public MongoGenericRepository(IMongoDatabase database)
     {
-        _collection = collection;
+        _collection = database.GetCollection<T>(typeof(T).Name);
     }
 
     public async Task<T?> GetByIdAsync(int id, bool includeDeleted = false)

--- a/src/ExampleData/MongoUnitOfWork.cs
+++ b/src/ExampleData/MongoUnitOfWork.cs
@@ -16,8 +16,7 @@ public class MongoUnitOfWork : IUnitOfWork
 
     public IGenericRepository<T> Repository<T>() where T : class, IValidatable, IBaseEntity, IRootEntity
     {
-        var collection = _database.GetCollection<T>(typeof(T).Name);
-        return new MongoGenericRepository<T>(collection);
+        return new MongoGenericRepository<T>(_database);
     }
 
     public Task<int> SaveChangesAsync() => Task.FromResult(0);

--- a/src/ExampleData/MongoValidationService.cs
+++ b/src/ExampleData/MongoValidationService.cs
@@ -1,5 +1,6 @@
 using System.Linq.Expressions;
 using MongoDB.Driver;
+using MongoDB.Driver.Linq;
 
 namespace ExampleData;
 

--- a/src/ExampleData/ServiceCollectionExtensions.cs
+++ b/src/ExampleData/ServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using MongoDB.Driver;
 
 namespace ExampleData;
 
@@ -26,6 +27,23 @@ public static class ServiceCollectionExtensions
     }
 
     /// <summary>
+    /// Adds MongoDB services using the provided connection string and database name.
+    /// Registers the Mongo client, database, validation service and unit of work.
+    /// </summary>
+    public static IServiceCollection AddExampleDataMongo(
+        this IServiceCollection services,
+        string connectionString,
+        string databaseName)
+    {
+        services.AddSingleton(new MongoClient(connectionString));
+        services.AddSingleton<IMongoDatabase>(sp =>
+            sp.GetRequiredService<MongoClient>().GetDatabase(databaseName));
+        services.AddScoped<IValidationService, MongoValidationService>();
+        services.AddScoped<IUnitOfWork, MongoUnitOfWork>();
+        return services;
+    }
+
+    /// <summary>
     /// Generic database setup used by production examples.
     /// Registers the DbContext, validation service and unit of work.
     /// </summary>
@@ -38,6 +56,24 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IValidationService, ValidationService>();
         services.AddScoped<IUnitOfWork, UnitOfWork<TContext>>();
         services.AddScoped(typeof(IGenericRepository<>), typeof(EfGenericRepository<>));
+        return services;
+    }
+
+    /// <summary>
+    /// Generic MongoDB setup mirroring <see cref="SetupDatabase{TContext}"/>.
+    /// Registers the Mongo client, database, validation service and unit of work.
+    /// </summary>
+    public static IServiceCollection SetupMongoDatabase(
+        this IServiceCollection services,
+        string connectionString,
+        string databaseName)
+    {
+        services.AddSingleton(new MongoClient(connectionString));
+        services.AddSingleton<IMongoDatabase>(sp =>
+            sp.GetRequiredService<MongoClient>().GetDatabase(databaseName));
+        services.AddScoped<IValidationService, MongoValidationService>();
+        services.AddScoped<IUnitOfWork, MongoUnitOfWork>();
+        services.AddScoped(typeof(IGenericRepository<>), typeof(MongoGenericRepository<>));
         return services;
     }
 }

--- a/tests/ExampleLib.BDDTests/MongoConfigurationSteps.cs
+++ b/tests/ExampleLib.BDDTests/MongoConfigurationSteps.cs
@@ -1,0 +1,33 @@
+using ExampleData;
+using MongoDB.Driver;
+using Microsoft.Extensions.DependencyInjection;
+using Reqnroll;
+using Xunit;
+
+namespace ExampleLib.BDDTests;
+
+[Binding]
+public class MongoConfigurationSteps
+{
+    private ServiceCollection? _services;
+    private ServiceProvider? _provider;
+
+    [Given("a new service collection")]
+    public void GivenNewServiceCollection()
+    {
+        _services = new ServiceCollection();
+    }
+
+    [When("AddExampleDataMongo is invoked")]
+    public void WhenAddExampleDataMongoInvoked()
+    {
+        _services!.AddExampleDataMongo("mongodb://localhost:27017", "bdd");
+        _provider = _services.BuildServiceProvider();
+    }
+
+    [Then("the Mongo database should resolve")]
+    public void ThenMongoDatabaseResolvable()
+    {
+        Assert.NotNull(_provider!.GetService<IMongoDatabase>());
+    }
+}

--- a/tests/ExampleLib.BDDTests/SetupMongoDatabaseSteps.cs
+++ b/tests/ExampleLib.BDDTests/SetupMongoDatabaseSteps.cs
@@ -1,0 +1,32 @@
+using ExampleData;
+using Microsoft.Extensions.DependencyInjection;
+using Reqnroll;
+using Xunit;
+
+namespace ExampleLib.BDDTests;
+
+[Binding]
+public class SetupMongoDatabaseSteps
+{
+    private ServiceCollection? _services;
+    private ServiceProvider? _provider;
+
+    [Given("a new service collection")]
+    public void GivenNewServiceCollection()
+    {
+        _services = new ServiceCollection();
+    }
+
+    [When("SetupMongoDatabase is invoked")]
+    public void WhenSetupMongoDatabaseInvoked()
+    {
+        _services!.SetupMongoDatabase("mongodb://localhost:27017", "bdd");
+        _provider = _services.BuildServiceProvider();
+    }
+
+    [Then("a Mongo unit of work can be resolved")]
+    public void ThenMongoUnitOfWorkResolvable()
+    {
+        Assert.IsType<MongoUnitOfWork>(_provider!.GetRequiredService<IUnitOfWork>());
+    }
+}

--- a/tests/ExampleLib.BDDTests/ValidationPlanFactorySteps.cs
+++ b/tests/ExampleLib.BDDTests/ValidationPlanFactorySteps.cs
@@ -19,7 +19,7 @@ public class Composite
 [Binding]
 public class ValidationPlanFactorySteps
 {
-    private List<ValidationPlan>? _plans;
+    private IReadOnlyList<ValidationPlan>? _plans;
 
     [When("creating validation plans for a composite type")]
     public void WhenCreatingPlans()

--- a/tests/ExampleLib.Tests/ServiceCollectionExtensionsTests.cs
+++ b/tests/ExampleLib.Tests/ServiceCollectionExtensionsTests.cs
@@ -3,6 +3,7 @@ using ExampleLib.Domain;
 using ExampleLib.Infrastructure;
 using MassTransit;
 using Microsoft.Extensions.DependencyInjection;
+using MongoDB.Driver;
 
 namespace ExampleLib.Tests;
 
@@ -47,5 +48,16 @@ public class ServiceCollectionExtensionsTests
         services.SetupDatabase<YourDbContext>("DataSource=:memory:");
         var provider = services.BuildServiceProvider();
         Assert.NotNull(provider.GetService<IUnitOfWork>());
+    }
+
+    [Fact]
+    public void SetupMongoDatabase_RegistersMongoServices()
+    {
+        var services = new ServiceCollection();
+        services.SetupMongoDatabase("mongodb://localhost:27017", "test");
+        var provider = services.BuildServiceProvider();
+        Assert.NotNull(provider.GetService<IMongoDatabase>());
+        Assert.IsType<MongoUnitOfWork>(provider.GetRequiredService<IUnitOfWork>());
+        Assert.NotNull(provider.GetService(typeof(IGenericRepository<YourEntity>)));
     }
 }


### PR DESCRIPTION
## Summary
- support Mongo setup in `ServiceCollectionExtensions`
- adjust Mongo repository to construct from `IMongoDatabase`
- update unit tests and BDD scenarios for Mongo support
- document Mongo helpers and examples

## Testing
- `dotnet test RAGStart.sln`
- `dotnet test RAGStart.sln --collect:"XPlat Code Coverage"`


------
https://chatgpt.com/codex/tasks/task_e_6859737cd484833098efe86cd7e49655