### PR TITLE
Add tasks for Mongo tests

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -10,6 +10,16 @@
             "label": "validation plan scenario",
             "type": "shell",
             "command": "dotnet test --filter ValidationPlanFactory"
+        },
+        {
+            "label": "mongo tests",
+            "type": "shell",
+            "command": "dotnet test --filter Mongo --no-restore --no-build"
+        },
+        {
+            "label": "mongo bdd scenarios",
+            "type": "shell",
+            "command": "dotnet test tests/ExampleLib.BDDTests/ExampleLib.BDDTests.csproj --no-restore --no-build --filter Mongo"
         }
     ]
 }

--- a/README.md
+++ b/README.md
@@ -178,6 +178,18 @@ repository operates on an `IMongoCollection<T>` and respects the `Validated`
 flag for soft deletes. The unit of work records `Nanny` documents just like the
 EF variant.
 
+### Running Mongo Tests
+
+- Execute only the Mongo related tests with:
+
+  ```bash
+  dotnet test --filter Mongo
+  ```
+- The **mongo tests** task in VS Code runs this command for you.
+- Another task called **mongo bdd scenarios** executes the BDD features from
+  `ExampleLib.BDDTests`.
+- Ensure a local MongoDB instance is available before running these tasks.
+
 ## Generating Validation Plans
 
 A `ValidationPlan` describes how to validate an entity using a metric strategy. The default


### PR DESCRIPTION
## Summary
- add Mongo test tasks to `.vscode/tasks.json`
- document how to run the Mongo tests

## Testing
- `dotnet test --no-restore --no-build`

------
https://chatgpt.com/codex/tasks/task_e_685976ef5b248330bddba354e01225d4