### PR TITLE
Add setup validation support

### DIFF
--- a/MetricsPipeline.Core/Infrastructure/ListGatherService.cs
+++ b/MetricsPipeline.Core/Infrastructure/ListGatherService.cs
@@ -55,4 +55,10 @@ public class ListGatherService : IGatherService, IWorkerService
             ? Task.FromResult(PipelineResult<IReadOnlyList<T>>.Failure("NoData"))
             : Task.FromResult(PipelineResult<IReadOnlyList<T>>.Success(list));
     }
+
+    /// <summary>
+    /// Alternate gather method used for testing custom worker methods.
+    /// </summary>
+    public Task<PipelineResult<IReadOnlyList<double>>> CustomGatherAsync(CancellationToken ct = default)
+        => FetchMetricsAsync(ct);
 }

--- a/MetricsPipeline.Core/Infrastructure/SetupValidationExtensions.cs
+++ b/MetricsPipeline.Core/Infrastructure/SetupValidationExtensions.cs
@@ -1,0 +1,34 @@
+namespace MetricsPipeline.Infrastructure;
+
+using System;
+using Microsoft.Extensions.DependencyInjection;
+
+/// <summary>
+/// Extension methods for configuring setup validation services.
+/// </summary>
+public static class SetupValidationExtensions
+{
+    /// <summary>
+    /// Registers the validation services and performs setup using the supplied options.
+    /// </summary>
+    public static IServiceCollection SetupValidation(this IServiceCollection services, Action<SetupValidationOptions> configure)
+    {
+        var options = new SetupValidationOptions();
+        configure(options);
+        services.AddSingleton(options);
+
+        var validator = new SetupValidator(options);
+        validator.Setup(services);
+        services.AddTransient<SetupValidator>(_ => new SetupValidator(options));
+        return services;
+    }
+
+    /// <summary>
+    /// Registers a typed validator that relies on the configured services.
+    /// </summary>
+    public static IServiceCollection AddSetupValidation<T>(this IServiceCollection services) where T : SetupValidator
+    {
+        services.AddTransient<T>();
+        return services;
+    }
+}

--- a/MetricsPipeline.Core/Infrastructure/SetupValidationOptions.cs
+++ b/MetricsPipeline.Core/Infrastructure/SetupValidationOptions.cs
@@ -1,0 +1,21 @@
+namespace MetricsPipeline.Infrastructure;
+
+using System;
+using System.Net.Http;
+using Microsoft.EntityFrameworkCore;
+
+/// <summary>
+/// Options controlling service registration for the setup validation phase.
+/// </summary>
+public class SetupValidationOptions
+{
+    /// <summary>
+    /// Optional database configuration delegate used when registering the context.
+    /// </summary>
+    public Action<DbContextOptionsBuilder>? ConfigureDb { get; set; }
+
+    /// <summary>
+    /// Optional configuration applied to the created <see cref="HttpClient"/>.
+    /// </summary>
+    public Action<IServiceProvider, HttpClient>? ConfigureClient { get; set; }
+}

--- a/MetricsPipeline.Core/Infrastructure/SetupValidator.cs
+++ b/MetricsPipeline.Core/Infrastructure/SetupValidator.cs
@@ -1,0 +1,51 @@
+namespace MetricsPipeline.Infrastructure;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Net.Http;
+
+/// <summary>
+/// Performs a multi step setup process when validating the host configuration.
+/// </summary>
+public class SetupValidator
+{
+    /// <summary>Options controlling registration.</summary>
+    protected readonly SetupValidationOptions Options;
+
+    /// <summary>Creates the validator with the supplied options.</summary>
+    public SetupValidator(SetupValidationOptions options)
+    {
+        Options = options;
+    }
+
+    /// <summary>Registers the required services in sequence.</summary>
+    public virtual void Setup(IServiceCollection services)
+    {
+        ConfigureBaseServices(services);
+        RegisterEntityFramework(services);
+        RegisterHttpClients(services);
+    }
+
+    /// <summary>Step 1: Configure base services.</summary>
+    protected virtual void ConfigureBaseServices(IServiceCollection services)
+    {
+        services.AddOptions();
+    }
+
+    /// <summary>Step 2: Register EF Core drivers using the options.</summary>
+    protected virtual void RegisterEntityFramework(IServiceCollection services)
+    {
+        if (Options.ConfigureDb != null)
+            services.AddDbContext<SummaryDbContext>(Options.ConfigureDb);
+    }
+
+    /// <summary>Step 3: Register any necessary HTTP clients.</summary>
+    protected virtual void RegisterHttpClients(IServiceCollection services)
+    {
+        if (Options.ConfigureClient != null)
+            services.AddHttpClient("validation", Options.ConfigureClient);
+        else
+            services.AddHttpClient("validation");
+    }
+}

--- a/MetricsPipeline.Tests/Features/4700-setup-validation.feature
+++ b/MetricsPipeline.Tests/Features/4700-setup-validation.feature
@@ -1,0 +1,11 @@
+Feature: SetupValidation
+  Verify setup validation extension methods register required services
+
+  Scenario: SetupValidation registers context and client
+    When the setup validation is executed
+    Then the service provider should resolve SummaryDbContext
+    And the service provider should resolve HttpClient
+
+  Scenario: AddSetupValidation resolves typed validator
+    When a typed validator is registered
+    Then the typed validator should resolve

--- a/MetricsPipeline.Tests/Steps/HostedWorkerTypeSteps.cs
+++ b/MetricsPipeline.Tests/Steps/HostedWorkerTypeSteps.cs
@@ -29,6 +29,8 @@ public class HostedWorkerTypeSteps
             o => o.UseInMemoryDatabase(Guid.NewGuid().ToString()),
             opts => opts.AddWorker = true);
         var provider = services.BuildServiceProvider();
+        var gather = provider.GetRequiredService<ListGatherService>();
+        gather.Metrics = new double[] { 1, 2, 3 };
         _worker = (GenericMetricsWorker)provider.GetServices<IHostedService>().Single(h => h is GenericMetricsWorker);
     }
 

--- a/MetricsPipeline.Tests/Steps/IntegrationSteps.cs
+++ b/MetricsPipeline.Tests/Steps/IntegrationSteps.cs
@@ -57,25 +57,16 @@ public class IntegrationSteps
     }
 
     [Given("the gather service returns:")]
-    public void GivenApiReturns(string endpoint, Table table)
+    public void GivenApiReturns(Table table)
     {
         var data = table.Rows.Select(r => double.Parse(r[0])).ToArray();
         _gather.Metrics = data;
-        _source = new Uri(endpoint);
     }
 
     [Given("the gather service returns no metric values")]
-    public void GivenApiOffline(string endpoint)
+    public void GivenApiOffline()
     {
         _gather.Metrics = Array.Empty<double>();
-        _source = new Uri(endpoint);
-    }
-
-    [Given("the gather service returns no metric values")]
-    public void GivenApiEmpty(string endpoint)
-    {
-        _gather.Metrics = Array.Empty<double>();
-        _source = new Uri(endpoint);
     }
 
     [When(@"the pipeline is executed")]

--- a/MetricsPipeline.Tests/Steps/SetupValidationSteps.cs
+++ b/MetricsPipeline.Tests/Steps/SetupValidationSteps.cs
@@ -1,0 +1,61 @@
+using System;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.EntityFrameworkCore;
+using MetricsPipeline.Infrastructure;
+using Reqnroll;
+
+namespace MetricsPipeline.Tests.Steps;
+
+[Binding]
+[Scope(Feature = "SetupValidation")]
+public class SetupValidationSteps
+{
+    private IServiceProvider _provider = null!;
+
+    [When("the setup validation is executed")]
+    public void WhenSetupExecuted()
+    {
+        var services = new ServiceCollection();
+        services.SetupValidation(o =>
+        {
+            o.ConfigureDb = b => b.UseInMemoryDatabase(Guid.NewGuid().ToString());
+            o.ConfigureClient = (_, c) => c.BaseAddress = new Uri("https://example.com/");
+        });
+        _provider = services.BuildServiceProvider();
+    }
+
+    [When("a typed validator is registered")]
+    public void WhenTypedValidatorRegistered()
+    {
+        var services = new ServiceCollection();
+        services.SetupValidation(o => o.ConfigureDb = b => b.UseInMemoryDatabase(Guid.NewGuid().ToString()));
+        services.AddSetupValidation<DemoValidator>();
+        _provider = services.BuildServiceProvider();
+    }
+
+    [Then("the service provider should resolve SummaryDbContext")]
+    public void ThenContextResolved()
+    {
+        _provider.GetService<SummaryDbContext>().Should().NotBeNull();
+    }
+
+    [Then("the service provider should resolve HttpClient")]
+    public void ThenClientResolved()
+    {
+        var factory = _provider.GetService<IHttpClientFactory>();
+        factory.Should().NotBeNull();
+        factory!.CreateClient("validation").Should().NotBeNull();
+    }
+
+    [Then("the typed validator should resolve")]
+    public void ThenValidatorResolved()
+    {
+        _provider.GetService<DemoValidator>().Should().NotBeNull();
+    }
+
+    internal class DemoValidator : SetupValidator
+    {
+        public DemoValidator(SetupValidationOptions options) : base(options) { }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -160,6 +160,26 @@ The console host fetches a small set of metric values from an in-memory source, 
 - **Worker classes** live under `MetricsPipeline.Core/Infrastructure/Workers` for reuse across hosts.
 - **WorkerType** lets you specify an alternative hosted worker. Set `opts.WorkerType = typeof(MyWorker)` or use the overload `AddMetricsPipeline(typeof(MyWorker), ...)`.
 
+## Setup Validation
+
+`SetupValidation` performs a three phase configuration that mirrors the production startup. It adds basic framework services, registers the selected EF Core provider and optionally configures an `HttpClient` for validation routines.
+
+```csharp
+services.SetupValidation(o =>
+{
+    o.ConfigureDb = b => b.UseInMemoryDatabase("check");
+    o.ConfigureClient = (_, c) => c.Timeout = TimeSpan.FromSeconds(5);
+});
+```
+
+Custom validators can then be registered via `AddSetupValidation<T>` and resolve any configured clients or contexts:
+
+```csharp
+services.AddSetupValidation<MyStartupValidator>();
+```
+
+Validators derived from `SetupValidator` execute against the service provider so common setup logic is reusable across projects.
+
 
 ## Architecture Overview
 


### PR DESCRIPTION
## Summary
- add setup validation options and validator
- support registering validation services via extension methods
- add end-to-end tests for the new setup validation pipeline
- generate a demo validator in BDD specs
- document setup validation usage in README
- fix test worker setup and custom gather method

## Testing
- `dotnet test --no-restore`
- `dotnet test --no-restore --no-build`


------
https://chatgpt.com/codex/tasks/task_e_6859a0d977d88330a2c4aa8da8180ae8