### PR TITLE
Add SetupValidationBuilder

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,17 @@ The helpers `AddExampleDataMongo` and `SetupMongoDatabase` register `MongoClient
 
 `SetupDatabase` configures the DbContext, validation service and generic repositories. Every repository works with the `Validated` soft delete filter enabled by default.
 
+### SetupValidationBuilder
+Use this fluent helper to collect configuration steps before applying them:
+
+```csharp
+var builder = new SetupValidationBuilder()
+    .UseSqlServer<YourDbContext>("DataSource=:memory:");
+builder.Apply(services);
+```
+
+`UseMongo` can be substituted to register MongoDB instead. Chaining these calls keeps startup code tidy when switching providers.
+
 ## Validation Helpers
 
 `SetupValidation` is an alias of `AddSaveValidation` for configuring summarisation plans. Multiple entities can be registered:

--- a/features/SetupValidationBuilder.feature
+++ b/features/SetupValidationBuilder.feature
@@ -1,0 +1,12 @@
+Feature: SetupValidationBuilder
+  Scenario: SQL Server configuration is applied
+    Given a new setup builder
+    When UseSqlServer is called
+    And Apply is invoked
+    Then a unit of work can be resolved
+
+  Scenario: Mongo configuration is applied
+    Given a new setup builder
+    When UseMongo is called
+    And Apply is invoked
+    Then a Mongo unit of work can be resolved

--- a/src/ExampleLib/ExampleLib.csproj
+++ b/src/ExampleLib/ExampleLib.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="MassTransit" Version="8.4.1" />
+    <ProjectReference Include="../ExampleData/ExampleData.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/ExampleLib/Infrastructure/SetupValidationBuilder.cs
+++ b/src/ExampleLib/Infrastructure/SetupValidationBuilder.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using ExampleData;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace ExampleLib.Infrastructure;
+
+/// <summary>
+/// Fluent builder capturing service configuration steps.
+/// </summary>
+public class SetupValidationBuilder
+{
+    private readonly List<Action<IServiceCollection>> _steps = new();
+
+    /// <summary>
+    /// Record SQL Server configuration using the specified DbContext.
+    /// </summary>
+    public SetupValidationBuilder UseSqlServer<TContext>(string connectionString)
+        where TContext : YourDbContext
+    {
+        _steps.Add(s => s.SetupDatabase<TContext>(connectionString));
+        return this;
+    }
+
+    /// <summary>
+    /// Record Mongo configuration with the provided connection string and database name.
+    /// </summary>
+    public SetupValidationBuilder UseMongo(string connectionString, string databaseName)
+    {
+        _steps.Add(s => s.SetupMongoDatabase(connectionString, databaseName));
+        return this;
+    }
+
+    /// <summary>
+    /// Apply all recorded steps to the service collection.
+    /// </summary>
+    public IServiceCollection Apply(IServiceCollection services)
+    {
+        foreach (var step in _steps)
+        {
+            step(services);
+        }
+        return services;
+    }
+}

--- a/tests/ExampleLib.BDDTests/SetupValidationBuilderSteps.cs
+++ b/tests/ExampleLib.BDDTests/SetupValidationBuilderSteps.cs
@@ -1,0 +1,54 @@
+using ExampleData;
+using ExampleLib.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+using MongoDB.Driver;
+using Reqnroll;
+using Xunit;
+
+namespace ExampleLib.BDDTests;
+
+[Binding]
+public class SetupValidationBuilderSteps
+{
+    private SetupValidationBuilder? _builder;
+    private ServiceCollection? _services;
+    private ServiceProvider? _provider;
+
+    [Given("a new setup builder")]
+    public void GivenNewBuilder()
+    {
+        _builder = new SetupValidationBuilder();
+        _services = new ServiceCollection();
+    }
+
+    [When("UseSqlServer is called")]
+    public void WhenUseSqlServer()
+    {
+        _builder!.UseSqlServer<YourDbContext>("DataSource=:memory:");
+    }
+
+    [When("UseMongo is called")]
+    public void WhenUseMongo()
+    {
+        _builder!.UseMongo("mongodb://localhost:27017", "bdd");
+    }
+
+    [When("Apply is invoked")]
+    public void WhenApplyInvoked()
+    {
+        _builder!.Apply(_services!);
+        _provider = _services!.BuildServiceProvider();
+    }
+
+    [Then("a unit of work can be resolved")]
+    public void ThenUnitOfWorkResolvable()
+    {
+        Assert.NotNull(_provider!.GetService<IUnitOfWork>());
+    }
+
+    [Then("a Mongo unit of work can be resolved")]
+    public void ThenMongoUnitOfWorkResolvable()
+    {
+        Assert.IsType<MongoUnitOfWork>(_provider!.GetRequiredService<IUnitOfWork>());
+    }
+}

--- a/tests/ExampleLib.Tests/SetupValidationBuilderTests.cs
+++ b/tests/ExampleLib.Tests/SetupValidationBuilderTests.cs
@@ -1,0 +1,33 @@
+using ExampleData;
+using ExampleLib.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+using MongoDB.Driver;
+using Xunit;
+
+namespace ExampleLib.Tests;
+
+public class SetupValidationBuilderTests
+{
+    [Fact]
+    public void UseSqlServer_ConfiguresUnitOfWork()
+    {
+        var services = new ServiceCollection();
+        var builder = new SetupValidationBuilder()
+            .UseSqlServer<YourDbContext>("DataSource=:memory:");
+        builder.Apply(services);
+        var provider = services.BuildServiceProvider();
+        Assert.NotNull(provider.GetService<IUnitOfWork>());
+    }
+
+    [Fact]
+    public void UseMongo_ConfiguresMongoServices()
+    {
+        var services = new ServiceCollection();
+        var builder = new SetupValidationBuilder()
+            .UseMongo("mongodb://localhost:27017", "test");
+        builder.Apply(services);
+        var provider = services.BuildServiceProvider();
+        Assert.NotNull(provider.GetService<IMongoDatabase>());
+        Assert.IsType<MongoUnitOfWork>(provider.GetRequiredService<IUnitOfWork>());
+    }
+}


### PR DESCRIPTION
## Summary
- add `SetupValidationBuilder` for recording database setup steps
- document the builder in README
- reference ExampleData from ExampleLib
- BDD feature and steps for the builder
- unit tests covering SQL Server and Mongo configurations

## Testing
- `dotnet test --no-build --no-restore` *(fails: Mongo connection timeout)*

------
https://chatgpt.com/codex/tasks/task_e_6859a8ad89688330a4353d7dcff290f2