### PR TITLE
Add SetupValidation builder

### DIFF
--- a/src/ExampleLib/Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/ExampleLib/Infrastructure/ServiceCollectionExtensions.cs
@@ -50,15 +50,18 @@ public static class ServiceCollectionExtensions
     }
 
     /// <summary>
-    /// Alias for <see cref="AddSaveValidation{T}"/> to match production setup examples.
+    /// Configure validation services using a fluent <see cref="SetupValidationBuilder"/>.
+    /// Recorded steps are applied to the service collection after <paramref name="configure"/> executes.
     /// </summary>
-    public static IServiceCollection SetupValidation<T>(
+    /// <param name="services">The service collection.</param>
+    /// <param name="configure">Action configuring the <see cref="SetupValidationBuilder"/>.</param>
+    public static IServiceCollection SetupValidation(
         this IServiceCollection services,
-        Func<T, decimal>? metricSelector = null,
-        ThresholdType thresholdType = ThresholdType.PercentChange,
-        decimal thresholdValue = 0.1m)
+        Action<SetupValidationBuilder> configure)
     {
-        return services.AddSaveValidation<T>(metricSelector, thresholdType, thresholdValue);
+        var builder = new SetupValidationBuilder();
+        configure(builder);
+        return builder.Apply(services);
     }
 
     private static decimal DefaultSelector<T>(T entity)

--- a/tests/ExampleLib.Tests/ServiceCollectionExtensionsTests.cs
+++ b/tests/ExampleLib.Tests/ServiceCollectionExtensionsTests.cs
@@ -33,12 +33,12 @@ public class ServiceCollectionExtensionsTests
     }
 
     [Fact]
-    public void SetupValidation_IsAlias()
+    public void SetupValidation_ExecutesBuilder()
     {
         var services = new ServiceCollection();
-        services.SetupValidation<YourEntity>(e => e.Id);
+        services.SetupValidation(b => b.UseSqlServer<YourDbContext>("DataSource=:memory:"));
         var provider = services.BuildServiceProvider();
-        Assert.NotNull(provider.GetService<IEntityRepository<YourEntity>>());
+        Assert.NotNull(provider.GetService<IUnitOfWork>());
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- support builder-based SetupValidation
- add unit test for applying SetupValidationBuilder
- document SetupValidation builder usage

## Testing
- `dotnet test --no-build --no-restore` *(fails: libcrypto.so.1.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_6859ac188cfc8330950e71be247b615f