### PR TITLE
Implement AddSetupValidation extension

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -10,6 +10,11 @@
             "label": "validation plan scenario",
             "type": "shell",
             "command": "dotnet test --filter ValidationPlanFactory"
+        },
+        {
+            "label": "add setup validation scenario",
+            "type": "shell",
+            "command": "dotnet test --filter AddSetupValidation"
         }
     ]
 }

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ RAGStart showcases an event‑driven validation workflow using .NET and MassTran
    dotnet run --project src/ExampleRunner
    ```
    The console logs show save events, validations and stored audits.
+5. Execute the `run tests` task in VS Code to verify everything locally.
+6. Use `AddSetupValidation` to configure the data layer and a default plan in a single statement.
 
 ## Validation Workflow
 
@@ -43,7 +45,7 @@ services.AddSaveValidation<Order>(o => o.LineAmounts.Sum(), ThresholdType.Percen
 ```
 * `MetricSelector` computes the metric value (order total in this case).
 * `ThresholdType` can be `RawDifference` or `PercentChange`.
-* `ThresholdValue` sets the allowable change.
+* `ThresholdValue` sets the allowable change and is easily tuned per entity.
 
 Override the plan later via `ISummarisationPlanStore`:
 
@@ -188,6 +190,13 @@ Both helpers return the service collection, so configuration can be chained flue
 services.SetupValidation(b => b.UseMongo("mongodb://localhost:27017", "demo"))
         .AddSaveValidation<Order>(o => o.LineAmounts.Sum());
 ```
+You can also perform both steps in one call using `AddSetupValidation`:
+
+```csharp
+services.AddSetupValidation<Order>(
+    b => b.UseSqlServer<YourDbContext>("DataSource=:memory:"),
+    o => o.LineAmounts.Sum());
+```
 
 The latest summarised metric is stored in the `Nanny` table whenever entities are saved through the unit of work.
 
@@ -236,4 +245,5 @@ across tables.
 
 Running `dotnet test` now also exercises the validation plan factory scenario.
 Convenient VS Code tasks are provided under `.vscode/tasks.json` for quick
-execution from the Codex interface.
+execution from the Codex interface. Tasks exist for running all tests,
+validating the plan factory and the new setup validation scenario.

--- a/features/AddSetupValidation.feature
+++ b/features/AddSetupValidation.feature
@@ -1,0 +1,5 @@
+Feature: AddSetupValidation Extension
+  Scenario: Builder configures and registers plan
+    Given a new service collection
+    When AddSetupValidation is invoked
+    Then a repository and validator can be resolved

--- a/src/ExampleLib/Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/ExampleLib/Infrastructure/ServiceCollectionExtensions.cs
@@ -50,6 +50,29 @@ public static class ServiceCollectionExtensions
     }
 
     /// <summary>
+    /// Convenience helper combining <see cref="SetupValidation"/> and
+    /// <see cref="AddSaveValidation{T}"/>. The builder action configures the
+    /// data layer while a default summarisation plan is registered for
+    /// <typeparamref name="T"/>.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="configure">Action configuring the setup builder.</param>
+    /// <param name="metricSelector">Metric selector for the plan.</param>
+    /// <param name="thresholdType">Threshold comparison type.</param>
+    /// <param name="thresholdValue">Allowed threshold value.</param>
+    public static IServiceCollection AddSetupValidation<T>(
+        this IServiceCollection services,
+        Action<SetupValidationBuilder> configure,
+        Func<T, decimal>? metricSelector = null,
+        ThresholdType thresholdType = ThresholdType.PercentChange,
+        decimal thresholdValue = 0.1m)
+    {
+        services.SetupValidation(configure);
+        services.AddSaveValidation<T>(metricSelector, thresholdType, thresholdValue);
+        return services;
+    }
+
+    /// <summary>
     /// Configure validation services using a fluent <see cref="SetupValidationBuilder"/>.
     /// Recorded steps are applied to the service collection after <paramref name="configure"/> executes.
     /// </summary>

--- a/tests/ExampleLib.BDDTests/AddSetupValidationSteps.cs
+++ b/tests/ExampleLib.BDDTests/AddSetupValidationSteps.cs
@@ -1,0 +1,37 @@
+using ExampleData;
+using ExampleLib.Domain;
+using ExampleLib.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+using Reqnroll;
+using Xunit;
+
+namespace ExampleLib.BDDTests;
+
+[Binding]
+public class AddSetupValidationSteps
+{
+    private ServiceCollection? _services;
+    private ServiceProvider? _provider;
+
+    [Given("a new service collection")]
+    public void GivenNewServiceCollection()
+    {
+        _services = new ServiceCollection();
+    }
+
+    [When("AddSetupValidation is invoked")]
+    public void WhenInvoked()
+    {
+        _services!.AddSetupValidation<YourEntity>(
+            b => b.UseSqlServer<YourDbContext>("DataSource=:memory:"),
+            e => e.Id);
+        _provider = _services.BuildServiceProvider();
+    }
+
+    [Then("a repository and validator can be resolved")]
+    public void ThenServicesResolvable()
+    {
+        Assert.NotNull(_provider!.GetService<IEntityRepository<YourEntity>>());
+        Assert.NotNull(_provider!.GetService<ISummarisationValidator<YourEntity>>());
+    }
+}

--- a/tests/ExampleLib.Tests/ServiceCollectionExtensionsTests.cs
+++ b/tests/ExampleLib.Tests/ServiceCollectionExtensionsTests.cs
@@ -33,6 +33,31 @@ public class ServiceCollectionExtensionsTests
     }
 
     [Fact]
+    public async Task AddSetupValidation_WiresEndToEnd()
+    {
+        var services = new ServiceCollection();
+        services.AddSetupValidation<YourEntity>(
+            b => b.UseSqlServer<YourDbContext>("DataSource=:memory:"),
+            e => e.Id);
+        var provider = services.BuildServiceProvider();
+        var bus = provider.GetRequiredService<IBusControl>();
+        await bus.StartAsync();
+        try
+        {
+            var repo = provider.GetRequiredService<IEntityRepository<YourEntity>>();
+            await repo.SaveAsync(new YourEntity { Id = 1 });
+            await Task.Delay(200);
+            var audits = provider.GetRequiredService<ISaveAuditRepository>();
+            var audit = audits.GetLastAudit(nameof(YourEntity), "1");
+            Assert.NotNull(audit);
+        }
+        finally
+        {
+            await bus.StopAsync();
+        }
+    }
+
+    [Fact]
     public void SetupValidation_ExecutesBuilder()
     {
         var services = new ServiceCollection();


### PR DESCRIPTION
## Summary
- allow AddSetupValidation to setup builder and plan in one call
- document AddSetupValidation in README
- add BDD scenario and unit test for AddSetupValidation
- include VS Code task to run the new scenario
- clarify README guidance and threshold explanation

## Testing
- `dotnet test --no-restore --no-build -v minimal` *(fails: libcrypto.so.1.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_6859ae9af734833080de4d810bf929d1