### PR TITLE
Implement manual validator service

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,26 @@ last computed metric is still recorded in the `Nanny` table for auditing.
 
 The latest summarised metric is stored in the `Nanny` table whenever entities are saved through the unit of work.
 
+### Manual Validation Service
+
+`ManualValidatorService` runs simple predicates registered per type. Use it when
+summarisation plans are overkill or you want quick checks:
+
+```csharp
+var rules = new Dictionary<Type, List<Func<object, bool>>>
+{
+    { typeof(Order), [o => ((Order)o).Total > 0] }
+};
+var validator = new ManualValidatorService(rules);
+bool ok = validator.Validate(new Order());
+```
+
+- Rules are stored in a dictionary keyed by runtime type.
+- When no rules exist validation succeeds by default.
+- Every rule for the type must return `true` for the instance to be valid.
+- Inject the rule dictionary via the constructor for testability.
+- BDD tests under `ManualValidatorService.feature` cover these scenarios.
+
 ### Nanny Records
 
 `Nanny` rows capture the last computed metric for each save along with the program name and a runtime identifier. This history can be inspected for audit or troubleshooting purposes.

--- a/features/ManualValidatorService.feature
+++ b/features/ManualValidatorService.feature
@@ -1,0 +1,17 @@
+Feature: ManualValidatorService
+  Validates objects using explicit rules
+
+  Scenario: No rules registered
+    Given a manual validator with no rules
+    When I validate the instance
+    Then the manual validation result should be true
+
+  Scenario: Rule passes
+    Given a manual validator with a rule that returns true
+    When I validate the instance
+    Then the manual validation result should be true
+
+  Scenario: Rule fails
+    Given a manual validator with a rule that returns false
+    When I validate the instance
+    Then the manual validation result should be false

--- a/src/ExampleLib/Domain/IManualValidatorService.cs
+++ b/src/ExampleLib/Domain/IManualValidatorService.cs
@@ -1,0 +1,13 @@
+namespace ExampleLib.Domain;
+
+/// <summary>
+/// Validates objects using manually registered rules.
+/// </summary>
+public interface IManualValidatorService
+{
+    /// <summary>
+    /// Validate the provided instance using rules for its runtime type.
+    /// Returns <c>true</c> when all rules succeed or no rules exist.
+    /// </summary>
+    bool Validate(object instance);
+}

--- a/src/ExampleLib/Domain/ManualValidatorService.cs
+++ b/src/ExampleLib/Domain/ManualValidatorService.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+
+namespace ExampleLib.Domain;
+
+/// <summary>
+/// Simple implementation of <see cref="IManualValidatorService"/>
+/// using a dictionary of validation rules keyed by type.
+/// </summary>
+public class ManualValidatorService : IManualValidatorService
+{
+    private readonly IDictionary<Type, List<Func<object, bool>>> _rules;
+
+    public ManualValidatorService(IDictionary<Type, List<Func<object, bool>>> rules)
+    {
+        _rules = rules ?? throw new ArgumentNullException(nameof(rules));
+    }
+
+    /// <inheritdoc />
+    public bool Validate(object instance)
+    {
+        if (instance == null) throw new ArgumentNullException(nameof(instance));
+        var type = instance.GetType();
+        if (!_rules.TryGetValue(type, out var rules) || rules.Count == 0)
+        {
+            return true;
+        }
+
+        foreach (var rule in rules)
+        {
+            if (!rule(instance))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/tests/ExampleLib.BDDTests/ManualValidatorSteps.cs
+++ b/tests/ExampleLib.BDDTests/ManualValidatorSteps.cs
@@ -1,0 +1,43 @@
+using ExampleLib.Domain;
+using Reqnroll;
+using System;
+using System.Collections.Generic;
+
+namespace ExampleLib.BDDTests;
+
+[Binding]
+public class ManualValidatorSteps
+{
+    private IManualValidatorService? _service;
+    private readonly object _instance = new();
+    private bool _result;
+
+    [Given("a manual validator with no rules")]
+    public void GivenValidatorWithNoRules()
+    {
+        _service = new ManualValidatorService(new Dictionary<Type, List<Func<object, bool>>>());
+    }
+
+    [Given("a manual validator with a rule that returns (true|false)")]
+    public void GivenValidatorWithRule(bool value)
+    {
+        var rules = new Dictionary<Type, List<Func<object, bool>>>
+        {
+            { typeof(object), new List<Func<object, bool>> { _ => value } }
+        };
+        _service = new ManualValidatorService(rules);
+    }
+
+    [When("I validate the instance")]
+    public void WhenIValidateTheInstance()
+    {
+        _result = _service!.Validate(_instance);
+    }
+
+    [Then("the manual validation result should be (true|false)")]
+    public void ThenResultShouldBe(bool expected)
+    {
+        if (_result != expected)
+            throw new Exception($"Expected {expected} but was {_result}");
+    }
+}


### PR DESCRIPTION
## Summary
- add `IManualValidatorService` with a `Validate` method
- implement `ManualValidatorService` using a rule dictionary
- document manual validator usage in the README
- add BDD feature and steps for manual validator scenarios

## Testing
- `dotnet test --no-restore --no-build` *(fails: MongoDB connection timeout)*

------
https://chatgpt.com/codex/tasks/task_e_685c39a2a60083308a43c2b7e0f84c5f