### PR TITLE
Add manual validator DI extension

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -20,6 +20,11 @@
             "label": "validation rule set scenario",
             "type": "shell",
             "command": "dotnet test --filter ValidationRuleSet"
+        },
+        {
+            "label": "manual validator service scenario",
+            "type": "shell",
+            "command": "dotnet test --filter AddValidatorService"
         }
     ]
 }

--- a/features/AddValidatorService.feature
+++ b/features/AddValidatorService.feature
@@ -1,0 +1,11 @@
+Feature: AddValidatorService Extension
+  Scenario: Services are registered
+    Given a new service collection
+    When AddValidatorService is invoked
+    Then the manual validator can be resolved
+
+  Scenario: Rules can be registered
+    Given a new service collection
+    When AddValidatorService is invoked
+    And AddValidatorRule is invoked
+    Then the manual validator validates successfully

--- a/tests/ExampleLib.BDDTests/AddValidatorServiceSteps.cs
+++ b/tests/ExampleLib.BDDTests/AddValidatorServiceSteps.cs
@@ -1,0 +1,47 @@
+using ExampleLib.Domain;
+using ExampleLib.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+using Reqnroll;
+using Xunit;
+
+namespace ExampleLib.BDDTests;
+
+[Binding]
+public class AddValidatorServiceSteps
+{
+    private ServiceCollection? _services;
+    private ServiceProvider? _provider;
+
+    [Given("a new service collection")]
+    public void GivenNewServiceCollection()
+    {
+        _services = new ServiceCollection();
+    }
+
+    [When("AddValidatorService is invoked")]
+    public void WhenAddValidatorServiceInvoked()
+    {
+        _services!.AddValidatorService();
+        _provider = _services.BuildServiceProvider();
+    }
+
+    [When("AddValidatorRule is invoked")]
+    public void WhenAddValidatorRuleInvoked()
+    {
+        _services!.AddValidatorRule<object>(_ => true);
+        _provider = _services.BuildServiceProvider();
+    }
+
+    [Then("the manual validator can be resolved")]
+    public void ThenManualValidatorResolvable()
+    {
+        Assert.NotNull(_provider!.GetService<IManualValidatorService>());
+    }
+
+    [Then("the manual validator validates successfully")]
+    public void ThenManualValidatorValidates()
+    {
+        var service = _provider!.GetRequiredService<IManualValidatorService>();
+        Assert.True(service.Validate(new object()));
+    }
+}

--- a/tests/ExampleLib.Tests/ServiceCollectionExtensionsTests.cs
+++ b/tests/ExampleLib.Tests/ServiceCollectionExtensionsTests.cs
@@ -4,6 +4,8 @@ using ExampleLib.Infrastructure;
 using MassTransit;
 using Microsoft.Extensions.DependencyInjection;
 using MongoDB.Driver;
+using System;
+using System.Collections.Generic;
 
 namespace ExampleLib.Tests;
 
@@ -84,5 +86,27 @@ public class ServiceCollectionExtensionsTests
         Assert.NotNull(provider.GetService<IMongoDatabase>());
         Assert.IsType<MongoUnitOfWork>(provider.GetRequiredService<IUnitOfWork>());
         Assert.NotNull(provider.GetService(typeof(IGenericRepository<YourEntity>)));
+    }
+
+    [Fact]
+    public void AddValidatorService_RegistersManualValidator()
+    {
+        var services = new ServiceCollection();
+        services.AddValidatorService();
+        var provider = services.BuildServiceProvider();
+        Assert.NotNull(provider.GetService<IManualValidatorService>());
+        Assert.NotNull(provider.GetService<IDictionary<Type, List<Func<object, bool>>>>());
+    }
+
+    [Fact]
+    public void AddValidatorRule_StoresRule()
+    {
+        var services = new ServiceCollection();
+        services.AddValidatorService();
+        services.AddValidatorRule<YourEntity>(_ => true);
+        var provider = services.BuildServiceProvider();
+        var dict = provider.GetRequiredService<IDictionary<Type, List<Func<object, bool>>>>();
+        Assert.True(dict.ContainsKey(typeof(YourEntity)));
+        Assert.Single(dict[typeof(YourEntity)]);
     }
 }


### PR DESCRIPTION
## Summary
- extend ServiceCollectionExtensions with ManualValidator helpers
- cover new registrations in BDD feature and steps
- add unit tests for the validator helpers
- document validator service registration in README
- include Codex task for AddValidatorService scenario

## Testing
- `dotnet test --no-restore --no-build` *(fails: libcrypto.so.1.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_685c4378e16083309d62580d092c18f9