### PR TITLE
Add manual validator DI extensions and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ RAGStart showcases an event‑driven validation workflow using .NET and MassTran
    The console logs show save events, validations and stored audits.
 5. Execute the `run tests` task in VS Code to verify everything locally.
 6. Use `AddSetupValidation` to configure the data layer and a default plan in a single statement.
+7. Call `AddValidatorService` and add rules with `AddValidatorRule` for quick predicate checks.
 
 ## Validation Workflow
 
@@ -234,6 +235,24 @@ bool ok = validator.Validate(new Order());
 - Every rule for the type must return `true` for the instance to be valid.
 - Inject the rule dictionary via the constructor for testability.
 - BDD tests under `ManualValidatorService.feature` cover these scenarios.
+
+To wire the validator through dependency injection:
+
+```csharp
+services.AddValidatorService()
+        .AddValidatorRule<Order>(o => o.Total > 0);
+var provider = services.BuildServiceProvider();
+var manual = provider.GetRequiredService<IManualValidatorService>();
+```
+
+You can fetch the rule dictionary from the provider to adjust rules at runtime:
+
+```csharp
+var dict = provider.GetRequiredService<IDictionary<Type, List<Func<object, bool>>>>();
+dict[typeof(Order)].Add(o => ((Order)o).Lines.Any());
+```
+
+BDD tests under `AddValidatorService.feature` confirm this registration path.
 
 ### Nanny Records
 

--- a/features/AddValidatorService.feature
+++ b/features/AddValidatorService.feature
@@ -1,0 +1,6 @@
+Feature: AddValidatorService Extension
+  Scenario: Manual validator can be resolved
+    Given a new service collection
+    When AddValidatorService is invoked
+    And AddValidatorRule is added
+    Then a manual validator can be resolved

--- a/src/ExampleLib/Infrastructure/ManualValidatorExtensions.cs
+++ b/src/ExampleLib/Infrastructure/ManualValidatorExtensions.cs
@@ -1,0 +1,40 @@
+using ExampleLib.Domain;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+
+namespace ExampleLib.Infrastructure;
+
+/// <summary>
+/// Extension methods for wiring up <see cref="ManualValidatorService"/>.
+/// </summary>
+public static class ManualValidatorExtensions
+{
+    private static IDictionary<Type, List<Func<object, bool>>>? _rules;
+
+    /// <summary>
+    /// Registers <see cref="IManualValidatorService"/> and the underlying rule dictionary.
+    /// </summary>
+    public static IServiceCollection AddValidatorService(this IServiceCollection services)
+    {
+        _rules = new Dictionary<Type, List<Func<object, bool>>>();
+        services.AddSingleton<IDictionary<Type, List<Func<object, bool>>>>(_rules);
+        services.AddSingleton<IManualValidatorService, ManualValidatorService>();
+        return services;
+    }
+
+    /// <summary>
+    /// Adds a validation rule for <typeparamref name="T"/>.
+    /// </summary>
+    public static IServiceCollection AddValidatorRule<T>(this IServiceCollection services, Func<T, bool> rule)
+    {
+        _rules ??= new Dictionary<Type, List<Func<object, bool>>>();
+        if (!_rules.TryGetValue(typeof(T), out var list))
+        {
+            list = new List<Func<object, bool>>();
+            _rules[typeof(T)] = list;
+        }
+        list.Add(o => rule((T)o));
+        return services;
+    }
+}

--- a/tests/ExampleLib.BDDTests/AddValidatorServiceSteps.cs
+++ b/tests/ExampleLib.BDDTests/AddValidatorServiceSteps.cs
@@ -1,0 +1,40 @@
+using ExampleLib.Domain;
+using ExampleData;
+using ExampleLib.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+using Reqnroll;
+using Xunit;
+
+namespace ExampleLib.BDDTests;
+
+[Binding]
+public class AddValidatorServiceSteps
+{
+    private ServiceCollection? _services;
+    private ServiceProvider? _provider;
+
+    [Given("a new service collection")]
+    public void GivenNewServiceCollection()
+    {
+        _services = new ServiceCollection();
+    }
+
+    [When("AddValidatorService is invoked")]
+    public void WhenAddValidatorService()
+    {
+        _services!.AddValidatorService();
+    }
+
+    [When("AddValidatorRule is added")]
+    public void WhenAddValidatorRule()
+    {
+        _services!.AddValidatorRule<YourEntity>(_ => true);
+        _provider = _services.BuildServiceProvider();
+    }
+
+    [Then("a manual validator can be resolved")]
+    public void ThenManualValidatorResolvable()
+    {
+        Assert.NotNull(_provider!.GetService<IManualValidatorService>());
+    }
+}

--- a/tests/ExampleLib.Tests/ManualValidatorServiceTests.cs
+++ b/tests/ExampleLib.Tests/ManualValidatorServiceTests.cs
@@ -1,0 +1,63 @@
+using ExampleLib.Domain;
+using ExampleData;
+using ExampleLib.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace ExampleLib.Tests;
+
+public class ManualValidatorServiceTests
+{
+    [Fact]
+    public void AddValidatorService_RegistersManualValidator()
+    {
+        var services = new ServiceCollection();
+        services.AddValidatorService();
+        services.AddValidatorRule<YourEntity>(_ => true);
+        var provider = services.BuildServiceProvider();
+
+        var validator = provider.GetService<IManualValidatorService>();
+        Assert.NotNull(validator);
+    }
+
+    [Fact]
+    public void Validate_ReturnsTrue_WhenRulesPass()
+    {
+        var services = new ServiceCollection();
+        services.AddValidatorService();
+        services.AddValidatorRule<YourEntity>(_ => true);
+        var provider = services.BuildServiceProvider();
+        var validator = provider.GetRequiredService<IManualValidatorService>();
+
+        var result = validator.Validate(new YourEntity());
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void Validate_ReturnsFalse_WhenRuleFails()
+    {
+        var services = new ServiceCollection();
+        services.AddValidatorService();
+        services.AddValidatorRule<YourEntity>(_ => false);
+        var provider = services.BuildServiceProvider();
+        var validator = provider.GetRequiredService<IManualValidatorService>();
+
+        var result = validator.Validate(new YourEntity());
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void Validate_ReturnsTrue_WhenNoRulesExist()
+    {
+        var services = new ServiceCollection();
+        services.AddValidatorService();
+        var provider = services.BuildServiceProvider();
+        var validator = provider.GetRequiredService<IManualValidatorService>();
+
+        var result = validator.Validate(new YourEntity());
+
+        Assert.True(result);
+    }
+}


### PR DESCRIPTION
## Summary
- register `ManualValidatorService` via `AddValidatorService`
- support rule registration through `AddValidatorRule<T>`
- demonstrate dependency injection usage in README
- verify DI wiring in new BDD steps
- add unit tests for manual validator behaviour

## Testing
- `dotnet test tests/ExampleLib.Tests/ExampleLib.Tests.csproj --filter ManualValidatorServiceTests --no-restore -v m`
- ❌ `dotnet test` *(fails: libcrypto.so.1.1 missing for Mongo2Go)*

------
https://chatgpt.com/codex/tasks/task_e_685c456b8578833095dd480713b4ae73