### PR TITLE
Add delete flow consumers and messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ RAGStart showcases an event‑driven validation workflow using .NET and MassTran
 5. Execute the `run tests` task in VS Code to verify everything locally.
 6. Use `AddSetupValidation` to configure the data layer and a default plan in a single statement.
 7. Call `AddValidatorService` to enable manual rule checks during startup.
+8. Register `AddDeleteValidation` or `AddDeleteCommit` to handle delete events.
 
 ## Validation Workflow
 
@@ -36,6 +37,16 @@ sequenceDiagram
     Consumer->>AuditRepo: AddAudit
     Consumer->>Bus: Publish SaveValidated
 ```
+
+## Delete Workflow
+
+Deletes follow a similar event pattern:
+
+1. A `DeleteRequested<T>` event is published when an entity should be removed.
+2. `DeleteValidationConsumer<T>` checks any manual rules and emits `DeleteValidated<T>`.
+3. If validated, `DeleteCommitConsumer<T>` publishes a `DeleteCommitted<T>` event.
+4. Service registration helpers `AddDeleteValidation<T>` and `AddDeleteCommit<T>` wire the consumers.
+5. Tests in `DeleteFlowTests` demonstrate the full validation and commit sequence.
 
 ### Configuring a Summarisation Plan
 

--- a/src/ExampleLib/Domain/DeleteCommitConsumer.cs
+++ b/src/ExampleLib/Domain/DeleteCommitConsumer.cs
@@ -1,0 +1,19 @@
+using ExampleLib.Messages;
+using MassTransit;
+
+namespace ExampleLib.Domain;
+
+/// <summary>
+/// Publishes a <see cref="DeleteCommitted{T}"/> event when validation succeeds.
+/// </summary>
+public class DeleteCommitConsumer<T> : IConsumer<DeleteValidated<T>>
+{
+    public async Task Consume(ConsumeContext<DeleteValidated<T>> context)
+    {
+        var msg = context.Message;
+        if (msg.Validated)
+        {
+            await context.Publish(new DeleteCommitted<T>(msg.AppName, msg.EntityType, msg.EntityId, msg.Payload));
+        }
+    }
+}

--- a/src/ExampleLib/Domain/DeleteValidationConsumer.cs
+++ b/src/ExampleLib/Domain/DeleteValidationConsumer.cs
@@ -1,0 +1,24 @@
+using ExampleLib.Messages;
+using MassTransit;
+
+namespace ExampleLib.Domain;
+
+/// <summary>
+/// Validates delete requests using <see cref="IManualValidatorService"/>.
+/// </summary>
+public class DeleteValidationConsumer<T> : IConsumer<DeleteRequested<T>>
+{
+    private readonly IManualValidatorService _validator;
+
+    public DeleteValidationConsumer(IManualValidatorService validator)
+    {
+        _validator = validator;
+    }
+
+    public async Task Consume(ConsumeContext<DeleteRequested<T>> context)
+    {
+        var msg = context.Message;
+        var valid = msg.Payload != null && _validator.Validate(msg.Payload);
+        await context.Publish(new DeleteValidated<T>(msg.AppName, msg.EntityType, msg.EntityId, msg.Payload, valid));
+    }
+}

--- a/src/ExampleLib/Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/ExampleLib/Infrastructure/ServiceCollectionExtensions.cs
@@ -51,6 +51,45 @@ public static class ServiceCollectionExtensions
     }
 
     /// <summary>
+    /// Register the services required to validate delete requests for <typeparamref name="T"/>.
+    /// </summary>
+    public static IServiceCollection AddDeleteValidation<T>(this IServiceCollection services)
+    {
+        services.AddValidatorService();
+        services.AddMassTransit(x =>
+        {
+            x.AddConsumer<DeleteValidationConsumer<T>>();
+            x.UsingInMemory((ctx, cfg) =>
+            {
+                cfg.ReceiveEndpoint("delete_requests_queue", e =>
+                {
+                    e.ConfigureConsumer<DeleteValidationConsumer<T>>(ctx);
+                });
+            });
+        });
+        return services;
+    }
+
+    /// <summary>
+    /// Register the services required to commit deletes for <typeparamref name="T"/>.
+    /// </summary>
+    public static IServiceCollection AddDeleteCommit<T>(this IServiceCollection services)
+    {
+        services.AddMassTransit(x =>
+        {
+            x.AddConsumer<DeleteCommitConsumer<T>>();
+            x.UsingInMemory((ctx, cfg) =>
+            {
+                cfg.ReceiveEndpoint("delete_commit_queue", e =>
+                {
+                    e.ConfigureConsumer<DeleteCommitConsumer<T>>(ctx);
+                });
+            });
+        });
+        return services;
+    }
+
+    /// <summary>
     /// Convenience helper combining <see cref="SetupValidation"/> and
     /// <see cref="AddSaveValidation{T}"/>. The builder action configures the
     /// data layer while a default summarisation plan is registered for

--- a/src/ExampleLib/Messages/DeleteCommitted.cs
+++ b/src/ExampleLib/Messages/DeleteCommitted.cs
@@ -1,0 +1,20 @@
+namespace ExampleLib.Messages;
+
+/// <summary>
+/// Event published when a delete operation has been committed.
+/// </summary>
+public class DeleteCommitted<T>
+{
+    public string AppName { get; }
+    public string EntityType { get; }
+    public string EntityId { get; }
+    public T? Payload { get; }
+
+    public DeleteCommitted(string appName, string entityType, string entityId, T? payload)
+    {
+        AppName = appName;
+        EntityType = entityType;
+        EntityId = entityId;
+        Payload = payload;
+    }
+}

--- a/src/ExampleLib/Messages/DeleteRequested.cs
+++ b/src/ExampleLib/Messages/DeleteRequested.cs
@@ -1,0 +1,12 @@
+namespace ExampleLib.Messages;
+
+/// <summary>
+/// Event published when a delete operation is requested for an entity.
+/// </summary>
+public class DeleteRequested<T>
+{
+    public string AppName { get; set; } = string.Empty;
+    public string EntityType { get; set; } = string.Empty;
+    public string EntityId { get; set; } = string.Empty;
+    public T? Payload { get; set; }
+}

--- a/src/ExampleLib/Messages/DeleteValidated.cs
+++ b/src/ExampleLib/Messages/DeleteValidated.cs
@@ -1,0 +1,22 @@
+namespace ExampleLib.Messages;
+
+/// <summary>
+/// Event published after a delete request has been validated.
+/// </summary>
+public class DeleteValidated<T>
+{
+    public string AppName { get; }
+    public string EntityType { get; }
+    public string EntityId { get; }
+    public T? Payload { get; }
+    public bool Validated { get; }
+
+    public DeleteValidated(string appName, string entityType, string entityId, T? payload, bool validated)
+    {
+        AppName = appName;
+        EntityType = entityType;
+        EntityId = entityId;
+        Payload = payload;
+        Validated = validated;
+    }
+}

--- a/tests/ExampleLib.BDDTests/UnitOfWorkExtensions.cs
+++ b/tests/ExampleLib.BDDTests/UnitOfWorkExtensions.cs
@@ -1,0 +1,14 @@
+using System.Threading;
+using System.Threading.Tasks;
+using ExampleData;
+
+namespace ExampleLib.BDDTests;
+
+public static class UnitOfWorkExtensions
+{
+    public static Task<int> SaveChangesAsync<TEntity>(this IUnitOfWork uow, ValidationRuleSet<TEntity> ruleSet, CancellationToken cancellationToken = default)
+        where TEntity : class, IValidatable, IBaseEntity, IRootEntity
+    {
+        return ((dynamic)uow).SaveChangesAsync(ruleSet, cancellationToken);
+    }
+}

--- a/tests/ExampleLib.Tests/DeleteFlowTests.cs
+++ b/tests/ExampleLib.Tests/DeleteFlowTests.cs
@@ -1,0 +1,60 @@
+using ExampleData;
+using ExampleLib.Domain;
+using ExampleLib.Messages;
+using MassTransit.Testing;
+using Moq;
+using Xunit;
+
+namespace ExampleLib.Tests;
+
+public class DeleteFlowTests
+{
+    [Fact]
+    public async Task ValidationConsumer_PublishesValidatedEvent()
+    {
+        var validator = new Mock<IManualValidatorService>();
+        validator.Setup(v => v.Validate(It.IsAny<YourEntity>())).Returns(true);
+
+        using var harness = new InMemoryTestHarness();
+        harness.Consumer(() => new DeleteValidationConsumer<YourEntity>(validator.Object));
+
+        await harness.Start();
+        try
+        {
+            var message = new DeleteRequested<YourEntity>
+            {
+                AppName = "App",
+                EntityType = nameof(YourEntity),
+                EntityId = "1",
+                Payload = new YourEntity { Id = 1 }
+            };
+            await harness.InputQueueSendEndpoint.Send(message);
+
+            Assert.True(await harness.Published.Any<DeleteValidated<YourEntity>>());
+        }
+        finally
+        {
+            await harness.Stop();
+        }
+    }
+
+    [Fact]
+    public async Task CommitConsumer_PublishesCommittedEventWhenValidated()
+    {
+        using var harness = new InMemoryTestHarness();
+        harness.Consumer(() => new DeleteCommitConsumer<YourEntity>());
+
+        await harness.Start();
+        try
+        {
+            var message = new DeleteValidated<YourEntity>("App", nameof(YourEntity), "1", new YourEntity { Id = 1 }, true);
+            await harness.InputQueueSendEndpoint.Send(message);
+
+            Assert.True(await harness.Published.Any<DeleteCommitted<YourEntity>>());
+        }
+        finally
+        {
+            await harness.Stop();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add delete event messages and consumers
- register delete event handlers in DI
- document delete workflow and registration steps
- add unit tests covering delete validation and commit
- helper extension for unit of work BDD tests

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build --no-restore` *(fails: MongoRepositoryTests due to MongoDB connection)*

------
https://chatgpt.com/codex/tasks/task_e_6866ab14e89c8330bc77de88e82f3e8d