### PR TITLE
Add commit consumer option for demo

### DIFF
--- a/MetricsPipeline.Tests/Steps/EventDrivenSteps.cs
+++ b/MetricsPipeline.Tests/Steps/EventDrivenSteps.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using ExampleLib.Domain;
+using FluentAssertions;
+using MassTransit;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Reqnroll;
+using Sample.EventDrivenDemo.ServiceA;
+using Sample.EventDrivenDemo.ServiceB;
+using Sample.EventDrivenDemo.ServiceB.Data;
+using Sample.EventDrivenDemo.Shared;
+using Xunit;
+
+namespace MetricsPipeline.Tests.Steps;
+
+[Binding]
+public class EventDrivenSteps
+{
+    private ServiceProvider _provider = null!;
+    private OrdersDbContext? _db;
+    private List<SaveAudit>? _audits;
+
+    [Given("commit consumer is enabled")]
+    public void GivenCommitConsumer()
+    {
+        _provider = Startup.Configure(true);
+        _db = _provider.GetRequiredService<OrdersDbContext>();
+    }
+
+    [When("the demo runs with (\\d+) orders")]
+    public async Task WhenDemoRuns(int count)
+    {
+        if (_provider == null) _provider = Startup.Configure();
+        var bus = _provider.GetRequiredService<IBusControl>();
+        await bus.StartAsync();
+        try
+        {
+            var client = new Client(_provider);
+            _audits = await client.RunDemoAsync(count);
+        }
+        finally
+        {
+            await bus.StopAsync();
+        }
+    }
+
+    [Then("both valid and invalid audits should exist")]
+    public void ThenAuditsExist()
+    {
+        _audits.Should().NotBeNull();
+        _audits!.Any(a => a.Validated).Should().BeTrue();
+        _audits.Any(a => !a.Validated).Should().BeTrue();
+    }
+
+    [Then("only valid orders should be stored")]
+    public void ThenOnlyValidOrdersStored()
+    {
+        _audits.Should().NotBeNull();
+        _db.Should().NotBeNull();
+        var validIds = _audits!.Where(a => a.Validated)
+            .Select(a => a.EntityId)
+            .ToHashSet();
+        _db!.Orders.Select(o => o.Id.ToString())
+            .Should().BeSubsetOf(validIds);
+    }
+}

--- a/RAGStart.sln
+++ b/RAGStart.sln
@@ -21,6 +21,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MetricsPipeline.Core", "src
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ExampleWorkerRunner", "src\ExampleWorkerRunner\ExampleWorkerRunner.csproj", "{D3C1DA49-DB3D-46B1-A224-80C4DD16B6DE}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sample.EventDrivenDemo", "Sample.EventDrivenDemo\Sample.EventDrivenDemo.csproj", "{0FD561C8-72BB-4D80-9EC8-DC19E8C16046}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -115,6 +117,18 @@ Global
 		{D3C1DA49-DB3D-46B1-A224-80C4DD16B6DE}.Release|x64.Build.0 = Release|Any CPU
 		{D3C1DA49-DB3D-46B1-A224-80C4DD16B6DE}.Release|x86.ActiveCfg = Release|Any CPU
 		{D3C1DA49-DB3D-46B1-A224-80C4DD16B6DE}.Release|x86.Build.0 = Release|Any CPU
+		{0FD561C8-72BB-4D80-9EC8-DC19E8C16046}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0FD561C8-72BB-4D80-9EC8-DC19E8C16046}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0FD561C8-72BB-4D80-9EC8-DC19E8C16046}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{0FD561C8-72BB-4D80-9EC8-DC19E8C16046}.Debug|x64.Build.0 = Debug|Any CPU
+		{0FD561C8-72BB-4D80-9EC8-DC19E8C16046}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{0FD561C8-72BB-4D80-9EC8-DC19E8C16046}.Debug|x86.Build.0 = Debug|Any CPU
+		{0FD561C8-72BB-4D80-9EC8-DC19E8C16046}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0FD561C8-72BB-4D80-9EC8-DC19E8C16046}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0FD561C8-72BB-4D80-9EC8-DC19E8C16046}.Release|x64.ActiveCfg = Release|Any CPU
+		{0FD561C8-72BB-4D80-9EC8-DC19E8C16046}.Release|x64.Build.0 = Release|Any CPU
+		{0FD561C8-72BB-4D80-9EC8-DC19E8C16046}.Release|x86.ActiveCfg = Release|Any CPU
+		{0FD561C8-72BB-4D80-9EC8-DC19E8C16046}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/README.md
+++ b/README.md
@@ -5,19 +5,38 @@ RAGStart showcases an event‑driven validation workflow using .NET and MassTran
 ## Quick Start
 
 1. Install the [.NET 9 SDK](https://dotnet.microsoft.com/en-us/download).
-2. Run `dotnet test` to build and execute all tests.
-3. Optionally run `dotnet test --collect:"XPlat Code Coverage"` to verify coverage (should exceed 80%).
-4. Launch the sample console app:
+2. Run `dotnet build` to compile all projects.
+3. Run `dotnet test` to execute the unit and BDD tests.
+4. Optionally run `dotnet test --collect:"XPlat Code Coverage"` to verify coverage (should exceed 80%).
+5. Launch the original example app:
    ```bash
    dotnet run --project src/ExampleRunner
    ```
    The console logs show save events, validations and stored audits.
-5. Execute the `run tests` task in VS Code to verify everything locally.
-6. Use `AddSetupValidation` to configure the data layer and a default plan in a single statement.
-7. Call `AddValidatorService` to enable manual rule checks during startup.
-8. Register `SaveCommitConsumer` using `AddSaveCommit` to audit committed saves.
-7. Call `AddValidatorService` to enable manual rule checks during startup.
-8. 8. Use `SaveChangesWithPlanAsync` to automatically apply registered summarisation plans when saving entities.
+6. Execute the `run tests` task in VS Code to verify everything locally.
+7. Use `AddSetupValidation` to configure the data layer and a default plan in a single statement.
+8. Call `AddValidatorService` to enable manual rule checks during startup.
+9. Register `SaveCommitConsumer` using `AddSaveCommit` to audit committed saves.
+10. Use `SaveChangesWithPlanAsync` to automatically apply registered summarisation plans when saving entities.
+
+## Event-Driven Demo
+
+The `Sample.EventDrivenDemo` project runs two services together:
+
+```bash
+dotnet run --project Sample.EventDrivenDemo
+```
+
+`ServiceA` randomly inflates order totals before sending save requests.
+`ServiceB` validates each request and records an audit. When the optional commit
+consumer is enabled only valid orders are persisted.
+
+### Sequence
+
+```text
+ServiceA -> Bus -> ValidationConsumer -> AuditRepo
+                              `-> CommitConsumer (optional) -> DbContext
+```
 
 8. Register `AddDeleteValidation` or `AddDeleteCommit` to handle delete events.
 ## Validation Workflow

--- a/Sample.EventDrivenDemo/Program.cs
+++ b/Sample.EventDrivenDemo/Program.cs
@@ -1,0 +1,17 @@
+using MassTransit;
+using Microsoft.Extensions.DependencyInjection;
+using Sample.EventDrivenDemo.ServiceA;
+using Sample.EventDrivenDemo.ServiceB;
+
+var provider = Startup.Configure();
+var bus = provider.GetRequiredService<IBusControl>();
+await bus.StartAsync();
+try
+{
+    var client = new Client(provider);
+    await client.RunDemoAsync(50);
+}
+finally
+{
+    await bus.StopAsync();
+}

--- a/Sample.EventDrivenDemo/Sample.EventDrivenDemo.csproj
+++ b/Sample.EventDrivenDemo/Sample.EventDrivenDemo.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+<PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../src/ExampleLib/ExampleLib.csproj" />
+    <ProjectReference Include="../src/ExampleData/ExampleData.csproj" />
+    <ProjectReference Include="../src/MetricsPipeline.Core/MetricsPipeline.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/Sample.EventDrivenDemo/ServiceA/Client.cs
+++ b/Sample.EventDrivenDemo/ServiceA/Client.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using ExampleLib.Domain;
+using Microsoft.Extensions.DependencyInjection;
+using Sample.EventDrivenDemo.Shared;
+
+namespace Sample.EventDrivenDemo.ServiceA;
+
+public class Client
+{
+    private readonly IEntityRepository<Order> _repo;
+    private readonly ISaveAuditRepository _audits;
+
+    public Client(IServiceProvider provider)
+    {
+        _repo = provider.GetRequiredService<IEntityRepository<Order>>();
+        _audits = provider.GetRequiredService<ISaveAuditRepository>();
+    }
+
+    public async Task<List<SaveAudit>> RunDemoAsync(int count)
+    {
+        var audits = new List<SaveAudit>();
+        for (int i = 0; i < count; i++)
+        {
+            var order = new Order { LineAmounts = new List<decimal> { 10m, 20m } };
+            if (Random.Shared.NextDouble() < 0.2)
+                order.LineAmounts[0] *= 10;
+            await _repo.SaveAsync(order);
+            await Task.Delay(100);
+            var audit = _audits.GetLastAudit(nameof(Order), order.Id.ToString());
+            if (audit != null) audits.Add(audit);
+            Console.WriteLine($"Order {order.Id} valid={audit?.Validated}");
+        }
+        return audits;
+    }
+}

--- a/Sample.EventDrivenDemo/ServiceB/CommitConsumer.cs
+++ b/Sample.EventDrivenDemo/ServiceB/CommitConsumer.cs
@@ -1,0 +1,21 @@
+using MassTransit;
+using ExampleLib.Domain;
+using Sample.EventDrivenDemo.Shared;
+using Sample.EventDrivenDemo.ServiceB.Data;
+
+namespace Sample.EventDrivenDemo.ServiceB;
+
+public class SaveCommitConsumer<T> : IConsumer<SaveValidated<T>> where T : class
+{
+    private readonly OrdersDbContext _db;
+    public SaveCommitConsumer(OrdersDbContext db) => _db = db;
+
+    public async Task Consume(ConsumeContext<SaveValidated<T>> ctx)
+    {
+        if (ctx.Message.Validated && ctx.Message.Payload != null)
+        {
+            _db.Add(ctx.Message.Payload);
+            await _db.SaveChangesAsync();
+        }
+    }
+}

--- a/Sample.EventDrivenDemo/ServiceB/Data/OrdersDbContext.cs
+++ b/Sample.EventDrivenDemo/ServiceB/Data/OrdersDbContext.cs
@@ -1,0 +1,12 @@
+using ExampleData;
+using Microsoft.EntityFrameworkCore;
+using Sample.EventDrivenDemo.Shared;
+
+namespace Sample.EventDrivenDemo.ServiceB.Data;
+
+public class OrdersDbContext : YourDbContext
+{
+    public OrdersDbContext(DbContextOptions<YourDbContext> options) : base(options) { }
+
+    public DbSet<Order> Orders => Set<Order>();
+}

--- a/Sample.EventDrivenDemo/ServiceB/Startup.cs
+++ b/Sample.EventDrivenDemo/ServiceB/Startup.cs
@@ -1,0 +1,42 @@
+using ExampleLib.Infrastructure;
+using ExampleLib.Domain;
+using MassTransit;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Sample.EventDrivenDemo.Shared;
+using Sample.EventDrivenDemo.ServiceB.Data;
+
+namespace Sample.EventDrivenDemo.ServiceB;
+
+public static class Startup
+{
+    public static ServiceProvider Configure(bool useCommit = false)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSaveValidation<Order>(
+            o => o.TotalAmount,
+            ThresholdType.PercentChange,
+            0.5m);
+
+        if (useCommit)
+        {
+            services.AddDbContext<OrdersDbContext>(o =>
+                o.UseInMemoryDatabase("orders"));
+
+            services.AddMassTransit(x =>
+            {
+                x.AddConsumer<SaveCommitConsumer<Order>>();
+                x.UsingInMemory((ctx, cfg) =>
+                {
+                    cfg.ReceiveEndpoint("save_commits_queue", e =>
+                    {
+                        e.ConfigureConsumer<SaveCommitConsumer<Order>>(ctx);
+                    });
+                });
+            });
+        }
+
+        return services.BuildServiceProvider();
+    }
+}

--- a/Sample.EventDrivenDemo/Shared/Order.cs
+++ b/Sample.EventDrivenDemo/Shared/Order.cs
@@ -1,0 +1,8 @@
+namespace Sample.EventDrivenDemo.Shared;
+
+public sealed class Order
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public List<decimal> LineAmounts { get; set; } = new();
+    public decimal TotalAmount => LineAmounts.Sum();
+}

--- a/features/EventDrivenRandomFailure.feature
+++ b/features/EventDrivenRandomFailure.feature
@@ -1,0 +1,11 @@
+Feature: EventDriven Order Processing
+  Demonstrates event-driven validation with occasional failures
+
+  Scenario: Orders are audited
+    When the demo runs with 5 orders
+    Then both valid and invalid audits should exist
+
+  Scenario: Commit consumer persists only valid orders
+    Given commit consumer is enabled
+    When the demo runs with 5 orders
+    Then only valid orders should be stored

--- a/src/ExampleData/Infrastructure/InMemorySummarisationPlanStore.cs
+++ b/src/ExampleData/Infrastructure/InMemorySummarisationPlanStore.cs
@@ -1,0 +1,21 @@
+using System.Collections.Concurrent;
+using ExampleLib.Domain;
+
+namespace ExampleData.Infrastructure;
+
+public class DataInMemorySummarisationPlanStore : ISummarisationPlanStore
+{
+    private readonly ConcurrentDictionary<Type, object> _plans = new();
+
+    public void AddPlan<T>(SummarisationPlan<T> plan)
+    {
+        _plans[typeof(T)] = plan;
+    }
+
+    public SummarisationPlan<T> GetPlan<T>()
+    {
+        if (_plans.TryGetValue(typeof(T), out var obj) && obj is SummarisationPlan<T> plan)
+            return plan;
+        throw new KeyNotFoundException($"No SummarisationPlan registered for type {typeof(T).Name}");
+    }
+}

--- a/src/ExampleData/ServiceCollectionExtensions.cs
+++ b/src/ExampleData/ServiceCollectionExtensions.cs
@@ -55,6 +55,7 @@ public static class ServiceCollectionExtensions
         services.AddDbContext<TContext>(o => o.UseSqlServer(connectionString));
         services.AddScoped<IValidationService, ValidationService>();
         services.AddScoped<IUnitOfWork, UnitOfWork<TContext>>();
+        services.AddSingleton<ExampleLib.Domain.ISummarisationPlanStore, ExampleData.Infrastructure.DataInMemorySummarisationPlanStore>();
         services.AddScoped(typeof(IGenericRepository<>), typeof(EfGenericRepository<>));
         return services;
     }
@@ -73,6 +74,7 @@ public static class ServiceCollectionExtensions
             sp.GetRequiredService<MongoClient>().GetDatabase(databaseName));
         services.AddScoped<IValidationService, MongoValidationService>();
         services.AddScoped<IUnitOfWork, MongoUnitOfWork>();
+        services.AddSingleton<ExampleLib.Domain.ISummarisationPlanStore, ExampleData.Infrastructure.DataInMemorySummarisationPlanStore>();
         services.AddScoped(typeof(IGenericRepository<>), typeof(MongoGenericRepository<>));
         return services;
     }

--- a/src/ExampleLib/Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/ExampleLib/Infrastructure/ServiceCollectionExtensions.cs
@@ -79,6 +79,13 @@ public static class ServiceCollectionExtensions
                 cfg.ReceiveEndpoint("save_commits_queue", e =>
                 {
                     e.ConfigureConsumer<SaveCommitConsumer<T>>(ctx);
+                });
+            });
+        });
+        return services;
+    }
+
+    /// <summary>
     /// Register the services required to validate delete requests for <typeparamref name="T"/>.
     /// </summary>
     public static IServiceCollection AddDeleteValidation<T>(this IServiceCollection services)

--- a/src/ExampleRunner/ExampleRunner.csproj
+++ b/src/ExampleRunner/ExampleRunner.csproj
@@ -7,6 +7,6 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="../ExampleLib/ExampleLib.csproj" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0-preview.4.24267.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
   </ItemGroup>
 </Project>

--- a/src/ExampleWorkerRunner/ExampleWorkerRunner.csproj
+++ b/src/ExampleWorkerRunner/ExampleWorkerRunner.csproj
@@ -8,6 +8,6 @@
   <ItemGroup>
     <ProjectReference Include="../ExampleLib/ExampleLib.csproj" />
     <ProjectReference Include="../MetricsPipeline.Core/MetricsPipeline.Core.csproj" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0-preview.4.24267.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- tweak Startup to optionally register a commit consumer
- update BDD steps to enable the consumer and verify persisted orders

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build --no-restore --collect:"XPlat Code Coverage"`

------
https://chatgpt.com/codex/tasks/task_e_6866bf561ef48330bb8834a983650c75