### PR TITLE
Fix merge conflicts and restore tests

### DIFF
--- a/MetricsPipeline.Tests/Steps/EventDrivenSteps.cs
+++ b/MetricsPipeline.Tests/Steps/EventDrivenSteps.cs
@@ -27,14 +27,8 @@ public class EventDrivenSteps
     [Given("commit consumer is enabled")]
     public void GivenCommitConsumer()
     {
-<<<<<< ic50pi-codex/plan-event-driven-crud-demo-implementation
         _provider = Startup.Configure(true);
         _db = _provider.GetRequiredService<OrdersDbContext>();
-======
-        _provider = Startup.Configure();
-        _db = new OrdersDbContext(new DbContextOptionsBuilder<YourDbContext>()
-            .UseInMemoryDatabase(Guid.NewGuid().ToString()).Options);
->>>>>> main
     }
 
     [When("the demo runs with (\\d+) orders")]
@@ -66,7 +60,6 @@ public class EventDrivenSteps
     public void ThenOnlyValidOrdersStored()
     {
         _audits.Should().NotBeNull();
-<<<<<< ic50pi-codex/plan-event-driven-crud-demo-implementation
         _db.Should().NotBeNull();
         var validIds = _audits!.Where(a => a.Validated)
             .Select(a => a.EntityId)
@@ -75,8 +68,3 @@ public class EventDrivenSteps
             .Should().BeSubsetOf(validIds);
     }
 }
-======
-        _audits!.All(a => a.Validated).Should().BeTrue();
-    }
-}
->>>>>> main

--- a/README.md
+++ b/README.md
@@ -452,3 +452,14 @@ Invalid or soft deleted records are hidden by the EF Core query filter.
 The service registration helper `AddPlan2Services` wires up the in-memory
 `DbContext`, generic repository and logging via Serilog.
 Inspect the `Nanny` table using the EF in-memory API to see audit entries.
+
+## Troubleshooting
+
+If tests or demos fail to run, review these suggestions:
+
+- Set `DOTNET_ROLL_FORWARD=Major` when running .NET 9 on older apps.
+- Run `dotnet restore` to pull missing packages.
+- Ignore MassTransit outbox warnings in demo projects.
+- Remove `bin` and `obj` folders after SDK upgrades to avoid stale builds.
+- Use `--no-restore` and `--no-build` flags for quick test iterations.
+

--- a/Sample.EventDrivenDemo/ServiceB/Startup.cs
+++ b/Sample.EventDrivenDemo/ServiceB/Startup.cs
@@ -6,16 +6,11 @@ using Microsoft.Extensions.DependencyInjection;
 using Sample.EventDrivenDemo.Shared;
 using Sample.EventDrivenDemo.ServiceB.Data;
 
-
 namespace Sample.EventDrivenDemo.ServiceB;
 
 public static class Startup
 {
-<<<<<< ic50pi-codex/plan-event-driven-crud-demo-implementation
     public static ServiceProvider Configure(bool useCommit = false)
-======
-    public static ServiceProvider Configure()
->>>>>> main
     {
         var services = new ServiceCollection();
         services.AddLogging();
@@ -23,7 +18,6 @@ public static class Startup
             o => o.TotalAmount,
             ThresholdType.PercentChange,
             0.5m);
-<<<<<< ic50pi-codex/plan-event-driven-crud-demo-implementation
 
         if (useCommit)
         {
@@ -46,8 +40,3 @@ public static class Startup
         return services.BuildServiceProvider();
     }
 }
-======
-        return services.BuildServiceProvider();
-    }
-}
->>>>>> main

--- a/Sample.EventDrivenDemo/Shared/Order.cs
+++ b/Sample.EventDrivenDemo/Shared/Order.cs
@@ -1,13 +1,3 @@
-<<<<<< ic50pi-codex/plan-event-driven-crud-demo-implementation
-namespace Sample.EventDrivenDemo.Shared;
-
-public sealed class Order
-{
-    public Guid Id { get; set; } = Guid.NewGuid();
-    public List<decimal> LineAmounts { get; set; } = new();
-    public decimal TotalAmount => LineAmounts.Sum();
-}
-======
 using ExampleData;
 
 namespace Sample.EventDrivenDemo.Shared;
@@ -19,4 +9,3 @@ public sealed class Order : IValidatable, IBaseEntity, IRootEntity
     public decimal TotalAmount => LineAmounts.Sum();
     public bool Validated { get; set; } = true;
 }
->>>>>> main

--- a/features/EventDrivenRandomFailure.feature
+++ b/features/EventDrivenRandomFailure.feature
@@ -8,8 +8,4 @@ Feature: EventDriven Order Processing
   Scenario: Commit consumer persists only valid orders
     Given commit consumer is enabled
     When the demo runs with 5 orders
-<<<<<< ic50pi-codex/plan-event-driven-crud-demo-implementation
     Then only valid orders should be stored
-======
-    Then only valid orders should be stored
->>>>>> main

--- a/src/ExampleData/Infrastructure/InMemorySummarisationPlanStore.cs
+++ b/src/ExampleData/Infrastructure/InMemorySummarisationPlanStore.cs
@@ -18,8 +18,4 @@ public class DataInMemorySummarisationPlanStore : ISummarisationPlanStore
             return plan;
         throw new KeyNotFoundException($"No SummarisationPlan registered for type {typeof(T).Name}");
     }
-<<<<<< ic50pi-codex/plan-event-driven-crud-demo-implementation
 }
-======
-}
->>>>>> main


### PR DESCRIPTION
## Summary
- fix leftover merge conflicts in Sample.EventDrivenDemo and MetricsPipeline tests
- restore InMemorySummarisationPlanStore implementation
- add troubleshooting guidance to README

## Testing
- `dotnet test --collect:"XPlat Code Coverage" --no-build --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_686c16c3ddd083309f2a20e35329a38c