### PR TITLE
Add Mongo save audit repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,8 @@ services.SetupDatabase<YourDbContext>("Server=.;Database=example;Trusted_Connect
 ```
 
 The setup now registers an `EfSaveAuditRepository` that persists `SaveAudit`
-records using Entity Framework Core.
+records using Entity Framework Core. When MongoDB is configured the
+equivalent `MongoSaveAuditRepository` is wired instead.
 Run `dotnet ef migrations add AddSaveAudit` to generate the initial migration
 and update the database.
 
@@ -286,6 +287,9 @@ var repo = services.BuildServiceProvider()
 
 Both helpers expect an `ISummarisationPlanStore` to be registered so `UnitOfWork` can resolve plans when saving.
 
+`AddSetupValidation` uses the same builder under the hood. When `UseMongo` is chosen the
+`MongoSaveAuditRepository` replaces the EF implementation automatically.
+
 The helpers `AddExampleDataMongo` and `SetupMongoDatabase` register `MongoClient`,
 `IMongoDatabase`, the validation service and unit of work automatically.
 
@@ -303,6 +307,8 @@ builder.Apply(services);
 `EfSaveAuditRepository` is registered automatically when a SQL database is
 configured, so calling `GetLastAudit` later will query the table instead of the
 in-memory store.
+Likewise `UseMongo` registers `MongoSaveAuditRepository` so audits are persisted
+to your MongoDB instance.
 ```
 
 `UseMongo` can be substituted to register MongoDB instead. Chaining these calls keeps startup code tidy when switching providers.

--- a/features/AddSetupValidation.feature
+++ b/features/AddSetupValidation.feature
@@ -3,3 +3,8 @@ Feature: AddSetupValidation Extension
     Given a new service collection
     When AddSetupValidation is invoked
     Then a repository and validator can be resolved
+
+  Scenario: Mongo builder registers mongo repository
+    Given a new service collection
+    When AddSetupValidation is invoked with Mongo
+    Then a mongo repository and validator can be resolved

--- a/src/ExampleLib/Infrastructure/MongoSaveAuditRepository.cs
+++ b/src/ExampleLib/Infrastructure/MongoSaveAuditRepository.cs
@@ -1,0 +1,36 @@
+using ExampleLib.Domain;
+using MongoDB.Driver;
+
+namespace ExampleLib.Infrastructure;
+
+/// <summary>
+/// MongoDB implementation of <see cref="ISaveAuditRepository"/>.
+/// Stores audits in the "SaveAudits" collection.
+/// </summary>
+public class MongoSaveAuditRepository : ISaveAuditRepository
+{
+    private readonly IMongoCollection<SaveAudit> _collection;
+
+    public MongoSaveAuditRepository(IMongoDatabase database)
+    {
+        _collection = database.GetCollection<SaveAudit>("SaveAudits");
+    }
+
+    /// <inheritdoc />
+    public SaveAudit? GetLastAudit(string entityType, string entityId)
+    {
+        var filter = Builders<SaveAudit>.Filter.Eq(a => a.EntityType, entityType) &
+                     Builders<SaveAudit>.Filter.Eq(a => a.EntityId, entityId);
+        return _collection.Find(filter)
+            .SortByDescending(a => a.Timestamp)
+            .FirstOrDefault();
+    }
+
+    /// <inheritdoc />
+    public void AddAudit(SaveAudit audit)
+    {
+        var filter = Builders<SaveAudit>.Filter.Eq(a => a.EntityType, audit.EntityType) &
+                     Builders<SaveAudit>.Filter.Eq(a => a.EntityId, audit.EntityId);
+        _collection.ReplaceOne(filter, audit, new ReplaceOptions { IsUpsert = true });
+    }
+}

--- a/src/ExampleLib/Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/ExampleLib/Infrastructure/ServiceCollectionExtensions.cs
@@ -142,9 +142,19 @@ public static class ServiceCollectionExtensions
         ThresholdType thresholdType = ThresholdType.PercentChange,
         decimal thresholdValue = 0.1m)
     {
-        services.SetupValidation(configure);
+        var builder = new SetupValidationBuilder();
+        configure(builder);
+        builder.Apply(services);
+
         services.AddSaveValidation<T>(metricSelector, thresholdType, thresholdValue);
-        services.AddScoped<ISaveAuditRepository, EfSaveAuditRepository>();
+        if (builder.UsesMongo)
+        {
+            services.AddScoped<ISaveAuditRepository, MongoSaveAuditRepository>();
+        }
+        else
+        {
+            services.AddScoped<ISaveAuditRepository, EfSaveAuditRepository>();
+        }
         return services;
     }
 

--- a/src/ExampleLib/Infrastructure/SetupValidationBuilder.cs
+++ b/src/ExampleLib/Infrastructure/SetupValidationBuilder.cs
@@ -11,6 +11,12 @@ namespace ExampleLib.Infrastructure;
 public class SetupValidationBuilder
 {
     private readonly List<Action<IServiceCollection>> _steps = new();
+    private bool _useMongo;
+
+    /// <summary>
+    /// Indicates whether MongoDB has been configured.
+    /// </summary>
+    internal bool UsesMongo => _useMongo;
 
     /// <summary>
     /// Record SQL Server configuration using the specified DbContext.
@@ -19,6 +25,7 @@ public class SetupValidationBuilder
         where TContext : YourDbContext
     {
         _steps.Add(s => s.SetupDatabase<TContext>(connectionString));
+        _useMongo = false;
         return this;
     }
 
@@ -28,6 +35,7 @@ public class SetupValidationBuilder
     public SetupValidationBuilder UseMongo(string connectionString, string databaseName)
     {
         _steps.Add(s => s.SetupMongoDatabase(connectionString, databaseName));
+        _useMongo = true;
         return this;
     }
 

--- a/tests/ExampleLib.BDDTests/AddSetupValidationSteps.cs
+++ b/tests/ExampleLib.BDDTests/AddSetupValidationSteps.cs
@@ -28,10 +28,26 @@ public class AddSetupValidationSteps
         _provider = _services.BuildServiceProvider();
     }
 
+    [When("AddSetupValidation is invoked with Mongo")]
+    public void WhenInvokedMongo()
+    {
+        _services!.AddSetupValidation<YourEntity>(
+            b => b.UseMongo("mongodb://localhost:27017", "bdd"),
+            e => e.Id);
+        _provider = _services.BuildServiceProvider();
+    }
+
     [Then("a repository and validator can be resolved")]
     public void ThenServicesResolvable()
     {
         Assert.NotNull(_provider!.GetService<IEntityRepository<YourEntity>>());
+        Assert.NotNull(_provider!.GetService<ISummarisationValidator<YourEntity>>());
+    }
+
+    [Then("a mongo repository and validator can be resolved")]
+    public void ThenMongoRepositoryResolvable()
+    {
+        Assert.IsType<MongoSaveAuditRepository>(_provider!.GetService<ISaveAuditRepository>());
         Assert.NotNull(_provider!.GetService<ISummarisationValidator<YourEntity>>());
     }
 }

--- a/tests/ExampleLib.Tests/ServiceCollectionExtensionsTests.cs
+++ b/tests/ExampleLib.Tests/ServiceCollectionExtensionsTests.cs
@@ -60,6 +60,28 @@ public class ServiceCollectionExtensionsTests
     }
 
     [Fact]
+    public void AddSetupValidation_RegistersEfRepository()
+    {
+        var services = new ServiceCollection();
+        services.AddSetupValidation<YourEntity>(
+            b => b.UseSqlServer<YourDbContext>("DataSource=:memory:"),
+            e => e.Id);
+        var provider = services.BuildServiceProvider();
+        Assert.IsType<EfSaveAuditRepository>(provider.GetRequiredService<ISaveAuditRepository>());
+    }
+
+    [Fact]
+    public void AddSetupValidation_RegistersMongoRepository()
+    {
+        var services = new ServiceCollection();
+        services.AddSetupValidation<YourEntity>(
+            b => b.UseMongo("mongodb://localhost:27017", "test"),
+            e => e.Id);
+        var provider = services.BuildServiceProvider();
+        Assert.IsType<MongoSaveAuditRepository>(provider.GetRequiredService<ISaveAuditRepository>());
+    }
+
+    [Fact]
     public void SetupValidation_ExecutesBuilder()
     {
         var services = new ServiceCollection();


### PR DESCRIPTION
## Summary
- implement `MongoSaveAuditRepository`
- register Mongo or EF repository via `AddSetupValidation`
- flag Mongo configuration in `SetupValidationBuilder`
- document new repository setup options
- test repository registration for both providers
- add BDD scenario for Mongo configuration

## Testing
- `dotnet test --collect:"XPlat Code Coverage"`

------
https://chatgpt.com/codex/tasks/task_e_686cfa8379088330b0bd5c1a318777f6