### PR TITLE
Add external validation flow configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -490,3 +490,23 @@ If tests or demos fail to run, review these suggestions:
 - Remove `bin` and `obj` folders after SDK upgrades to avoid stale builds.
 - Use `--no-restore` and `--no-build` flags for quick test iterations.
 
+
+## External Flow Configuration
+
+Validation flows can be defined in a JSON file and loaded at runtime. The file may contain a single object or an array of objects. Each entry specifies the entity type and which flows to enable.
+
+```json
+[
+  { "Type": "ExampleData.YourEntity, ExampleData", "SaveValidation": true }
+]
+```
+
+Load the file and register the flows during startup:
+
+```csharp
+var json = File.ReadAllText("flows.json");
+var options = ValidationFlowOptions.Load(json);
+services.AddValidationFlows(options);
+```
+
+This approach lets you adjust validation logic without recompiling the application. Both unit tests and BDD scenarios cover the configuration loader.

--- a/features/ValidationFlows.feature
+++ b/features/ValidationFlows.feature
@@ -1,0 +1,18 @@
+Feature: ValidationFlows configuration
+  Scenario: Configure from JSON array
+    Given the validation flow configuration
+      """
+      [
+        { "Type": "ExampleData.YourEntity, ExampleData", "SaveValidation": true }
+      ]
+      """
+    When the flows are applied
+    Then a repository for YourEntity is available
+
+  Scenario: Configure from JSON object
+    Given the validation flow configuration
+      """
+      { "Type": "ExampleData.YourEntity, ExampleData", "SaveValidation": true }
+      """
+    When the flows are applied
+    Then a repository for YourEntity is available

--- a/src/ExampleData/Infrastructure/MongoCollectionInterceptor.cs
+++ b/src/ExampleData/Infrastructure/MongoCollectionInterceptor.cs
@@ -13,7 +13,9 @@ public interface IMongoCollectionInterceptor<T>
     Task<UpdateResult> UpdateOneAsync(FilterDefinition<T> filter, UpdateDefinition<T> update, CancellationToken cancellationToken = default);
     Task<DeleteResult> DeleteOneAsync(FilterDefinition<T> filter, CancellationToken cancellationToken = default);
     IFindFluent<T, T> Find(FilterDefinition<T> filter);
-    Task<long> CountDocumentsAsync(FilterDefinition<T> filter, CancellationToken cancellationToken = default);
+    Task<long> CountDocumentsAsync(FilterDefinition<T> filter,
+        CountOptions? options = null,
+        CancellationToken cancellationToken = default);
 }
 
 /// <summary>
@@ -50,6 +52,8 @@ public class MongoCollectionInterceptor<T> : IMongoCollectionInterceptor<T>
 
     public IFindFluent<T, T> Find(FilterDefinition<T> filter) => _inner.Find(filter);
 
-    public Task<long> CountDocumentsAsync(FilterDefinition<T> filter, CancellationToken cancellationToken = default)
-        => _inner.CountDocumentsAsync(filter, cancellationToken);
+    public Task<long> CountDocumentsAsync(FilterDefinition<T> filter,
+        CountOptions? options = null,
+        CancellationToken cancellationToken = default)
+        => _inner.CountDocumentsAsync(filter, options, cancellationToken);
 }

--- a/src/ExampleLib/Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/ExampleLib/Infrastructure/ServiceCollectionExtensions.cs
@@ -209,4 +209,45 @@ public static class ServiceCollectionExtensions
         list.Add(o => rule((T)o));
         return services;
     }
+
+    /// <summary>
+    /// Register validation flows based on external configuration.
+    /// </summary>
+    public static IServiceCollection AddValidationFlows(this IServiceCollection services, ValidationFlowOptions options)
+    {
+        foreach (var flow in options.Flows)
+        {
+            var type = Type.GetType(flow.Type);
+            if (type == null) continue;
+            if (flow.SaveValidation)
+            {
+                typeof(ServiceCollectionExtensions)
+                    .GetMethod(nameof(AddSaveValidation))!
+                    .MakeGenericMethod(type)
+                    .Invoke(null, new object[] { services, null, ThresholdType.PercentChange, 0.1m });
+            }
+            if (flow.SaveCommit)
+            {
+                typeof(ServiceCollectionExtensions)
+                    .GetMethod(nameof(AddSaveCommit))!
+                    .MakeGenericMethod(type)
+                    .Invoke(null, new object[] { services });
+            }
+            if (flow.DeleteValidation)
+            {
+                typeof(ServiceCollectionExtensions)
+                    .GetMethod(nameof(AddDeleteValidation))!
+                    .MakeGenericMethod(type)
+                    .Invoke(null, new object[] { services });
+            }
+            if (flow.DeleteCommit)
+            {
+                typeof(ServiceCollectionExtensions)
+                    .GetMethod(nameof(AddDeleteCommit))!
+                    .MakeGenericMethod(type)
+                    .Invoke(null, new object[] { services });
+            }
+        }
+        return services;
+    }
 }

--- a/src/ExampleLib/Infrastructure/ValidationFlowDefinition.cs
+++ b/src/ExampleLib/Infrastructure/ValidationFlowDefinition.cs
@@ -1,0 +1,22 @@
+namespace ExampleLib.Infrastructure;
+
+/// <summary>
+/// Defines which validation services should be registered for a given entity.
+/// </summary>
+public class ValidationFlowDefinition
+{
+    /// <summary>The assembly qualified name of the entity type.</summary>
+    public string Type { get; set; } = string.Empty;
+
+    /// <summary>Register save validation.</summary>
+    public bool SaveValidation { get; set; }
+
+    /// <summary>Register save commit auditing.</summary>
+    public bool SaveCommit { get; set; }
+
+    /// <summary>Register delete validation.</summary>
+    public bool DeleteValidation { get; set; }
+
+    /// <summary>Register delete commit auditing.</summary>
+    public bool DeleteCommit { get; set; }
+}

--- a/src/ExampleLib/Infrastructure/ValidationFlowOptions.cs
+++ b/src/ExampleLib/Infrastructure/ValidationFlowOptions.cs
@@ -1,0 +1,28 @@
+using System.Text.Json;
+
+namespace ExampleLib.Infrastructure;
+
+/// <summary>
+/// Collection of <see cref="ValidationFlowDefinition"/> instances.
+/// Supports loading from JSON where the root may be a single object or an array.
+/// </summary>
+public class ValidationFlowOptions
+{
+    public List<ValidationFlowDefinition> Flows { get; set; } = new();
+
+    public static ValidationFlowOptions Load(string json)
+    {
+        var trimmed = json.TrimStart();
+        if (trimmed.StartsWith("["))
+        {
+            var flows = JsonSerializer.Deserialize<List<ValidationFlowDefinition>>(json);
+            return new ValidationFlowOptions { Flows = flows ?? new List<ValidationFlowDefinition>() };
+        }
+        else
+        {
+            var flow = JsonSerializer.Deserialize<ValidationFlowDefinition>(json);
+            var list = flow != null ? new List<ValidationFlowDefinition> { flow } : new List<ValidationFlowDefinition>();
+            return new ValidationFlowOptions { Flows = list };
+        }
+    }
+}

--- a/tests/ExampleLib.BDDTests/MongoRepoSteps.cs
+++ b/tests/ExampleLib.BDDTests/MongoRepoSteps.cs
@@ -1,4 +1,7 @@
 using ExampleData;
+using ExampleData.Infrastructure;
+using ExampleLib.Domain;
+using ExampleLib.Infrastructure;
 using Mongo2Go;
 using MongoDB.Driver;
 using Reqnroll;
@@ -18,7 +21,10 @@ public class MongoRepoSteps
         _runner = MongoDbRunner.Start();
         var client = new MongoClient(_runner.ConnectionString);
         _database = client.GetDatabase("bddrepo");
-        _repository = new MongoGenericRepository<YourEntity>(_database);
+        var store = new ExampleData.Infrastructure.DataInMemorySummarisationPlanStore();
+        store.AddPlan(new ExampleLib.Domain.SummarisationPlan<YourEntity>(e => e.Id, ExampleLib.Domain.ThresholdType.RawDifference, 0));
+        var uow = new MongoUnitOfWork(_database, new MongoValidationService(_database), store);
+        _repository = new MongoGenericRepository<YourEntity>(_database, uow);
     }
 
     [Given("a clean mongo database")]

--- a/tests/ExampleLib.BDDTests/ValidationFlowConfigSteps.cs
+++ b/tests/ExampleLib.BDDTests/ValidationFlowConfigSteps.cs
@@ -1,0 +1,36 @@
+using ExampleData;
+using ExampleLib.Domain;
+using ExampleLib.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+using Reqnroll;
+using Xunit;
+
+namespace ExampleLib.BDDTests;
+
+[Binding]
+public class ValidationFlowConfigSteps
+{
+    private string? _json;
+    private ServiceProvider? _provider;
+
+    [Given("the validation flow configuration")]
+    public void GivenConfiguration(string multilineText)
+    {
+        _json = multilineText;
+    }
+
+    [When("the flows are applied")]
+    public void WhenApplied()
+    {
+        var opts = ValidationFlowOptions.Load(_json!);
+        var services = new ServiceCollection();
+        services.AddValidationFlows(opts);
+        _provider = services.BuildServiceProvider();
+    }
+
+    [Then("a repository for YourEntity is available")]
+    public void ThenRepositoryAvailable()
+    {
+        Assert.NotNull(_provider!.GetService<IEntityRepository<YourEntity>>());
+    }
+}

--- a/tests/ExampleLib.Tests/MongoInterceptorTests.cs
+++ b/tests/ExampleLib.Tests/MongoInterceptorTests.cs
@@ -1,5 +1,7 @@
 using ExampleData;
 using ExampleData.Infrastructure;
+using ExampleLib.Domain;
+using ExampleLib.Infrastructure;
 using Mongo2Go;
 using MongoDB.Driver;
 using Xunit;

--- a/tests/ExampleLib.Tests/MongoRepositoryTests.cs
+++ b/tests/ExampleLib.Tests/MongoRepositoryTests.cs
@@ -1,4 +1,7 @@
 using ExampleData;
+using ExampleData.Infrastructure;
+using ExampleLib.Infrastructure;
+using ExampleLib.Domain;
 using Mongo2Go;
 using MongoDB.Driver;
 using Xunit;
@@ -16,7 +19,10 @@ public class MongoRepositoryTests : IDisposable
         _runner = MongoDbRunner.Start();
         var client = new MongoClient(_runner.ConnectionString);
         _database = client.GetDatabase("repo-tests");
-        _repo = new MongoGenericRepository<YourEntity>(_database);
+        var store = new DataInMemorySummarisationPlanStore();
+        store.AddPlan(new SummarisationPlan<YourEntity>(e => e.Id, ThresholdType.RawDifference, 0));
+        var uow = new MongoUnitOfWork(_database, new MongoValidationService(_database), store);
+        _repo = new MongoGenericRepository<YourEntity>(_database, uow);
     }
 
     private async Task ResetAsync()

--- a/tests/ExampleLib.Tests/ValidationFlowOptionsTests.cs
+++ b/tests/ExampleLib.Tests/ValidationFlowOptionsTests.cs
@@ -1,0 +1,37 @@
+using ExampleData;
+using ExampleLib.Domain;
+using ExampleLib.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace ExampleLib.Tests;
+
+public class ValidationFlowOptionsTests
+{
+    [Fact]
+    public void Load_SingleObject_ParsesFlow()
+    {
+        string json = "{ \"Type\": \"ExampleData.YourEntity, ExampleData\", \"SaveValidation\": true }";
+        var opts = ValidationFlowOptions.Load(json);
+        Assert.Single(opts.Flows);
+    }
+
+    [Fact]
+    public void Load_Array_ParsesFlows()
+    {
+        string json = "[ { \"Type\": \"ExampleData.YourEntity, ExampleData\", \"SaveValidation\": true }, { \"Type\": \"ExampleData.YourEntity, ExampleData\", \"DeleteValidation\": true } ]";
+        var opts = ValidationFlowOptions.Load(json);
+        Assert.Equal(2, opts.Flows.Count);
+    }
+
+    [Fact]
+    public void AddValidationFlows_RegistersServices()
+    {
+        string json = "{ \"Type\": \"ExampleData.YourEntity, ExampleData\", \"SaveValidation\": true }";
+        var opts = ValidationFlowOptions.Load(json);
+        var services = new ServiceCollection();
+        services.AddValidationFlows(opts);
+        var provider = services.BuildServiceProvider();
+        Assert.NotNull(provider.GetService(typeof(IEntityRepository<ExampleData.YourEntity>)));
+    }
+}


### PR DESCRIPTION
## Summary
- allow loading validation flows from external JSON using new ValidationFlowOptions class
- support configuring flows via `AddValidationFlows`
- document JSON-based configuration in README
- update Mongo tests for new repository constructors
- add unit & BDD tests covering the new configuration loader

## Testing
- `dotnet build --no-restore`
- `DOTNET_ROLL_FORWARD=Major dotnet test --no-build --verbosity minimal` *(fails: Could not connect to MongoDB)*

------
https://chatgpt.com/codex/tasks/task_e_686d28ea3fd08330bd353a41b2455edd