### PR TITLE
Enable summarisation plan for sequence validation

### DIFF
--- a/features/SequencePlan.feature
+++ b/features/SequencePlan.feature
@@ -1,0 +1,12 @@
+Feature: Sequence Validator with Plan
+  Scenario: Differences within threshold are valid
+    Given a summarisation plan using RawDifference threshold 5
+    And a sequence "10,12,13" for server "a"
+    When validating the sequence by server
+    Then the validation result should be true
+
+  Scenario: Excessive change fails validation
+    Given a summarisation plan using RawDifference threshold 5
+    And a sequence "10,20,12" for server "a"
+    When validating the sequence by server
+    Then the validation result should be false

--- a/src/ExampleLib/Domain/SequenceValidator.cs
+++ b/src/ExampleLib/Domain/SequenceValidator.cs
@@ -78,4 +78,31 @@ public static class SequenceValidator
     {
         return Validate(items, wheneverSelector, valueSelector, (c, p) => EqualityComparer<TValue>.Default.Equals(c, p));
     }
+
+    /// <summary>
+    /// Validates a sequence using a <see cref="SummarisationPlan{T}"/>. Metric values
+    /// are compared according to the plan's threshold rules.
+    /// </summary>
+    public static bool Validate<T, TKey>(
+        IEnumerable<T> items,
+        Func<T, TKey> wheneverSelector,
+        SummarisationPlan<T> plan)
+    {
+        if (plan == null) throw new ArgumentNullException(nameof(plan));
+
+        return Validate(items, wheneverSelector, plan.MetricSelector, (cur, prev) =>
+        {
+            switch (plan.ThresholdType)
+            {
+                case ThresholdType.RawDifference:
+                    return Math.Abs(cur - prev) <= plan.ThresholdValue;
+                case ThresholdType.PercentChange:
+                    if (prev == 0) return cur == 0;
+                    var change = Math.Abs((cur - prev) / prev);
+                    return change <= plan.ThresholdValue;
+                default:
+                    return true;
+            }
+        });
+    }
 }

--- a/src/ExampleLib/Domain/SequenceValidator.cs
+++ b/src/ExampleLib/Domain/SequenceValidator.cs
@@ -101,7 +101,7 @@ public static class SequenceValidator
                     var change = Math.Abs((cur - prev) / prev);
                     return change <= plan.ThresholdValue;
                 default:
-                    return true;
+                    throw new NotSupportedException($"Unsupported ThresholdType: {plan.ThresholdType}");
             }
         });
     }

--- a/tests/ExampleLib.BDDTests/SequenceValidatorPlanSteps.cs
+++ b/tests/ExampleLib.BDDTests/SequenceValidatorPlanSteps.cs
@@ -1,0 +1,41 @@
+using ExampleData;
+using ExampleLib.Domain;
+using Reqnroll;
+
+namespace ExampleLib.BDDTests;
+
+[Binding]
+public class SequenceValidatorPlanSteps
+{
+    private SummarisationPlan<YourEntity>? _plan;
+    private List<YourEntity> _items = new();
+    private bool _result;
+
+    [Given("a summarisation plan using (.*) threshold (.*)")]
+    public void GivenPlan(string type, decimal threshold)
+    {
+        var t = Enum.Parse<ThresholdType>(type);
+        _plan = new SummarisationPlan<YourEntity>(e => e.Id, t, threshold);
+    }
+
+    [Given("a sequence \"(.*)\" for server \"(.*)\"")]
+    public void GivenSequence(string csv, string server)
+    {
+        _items = csv.Split(',')
+            .Select(v => new YourEntity { Id = int.Parse(v), Name = server })
+            .ToList();
+    }
+
+    [When("validating the sequence by server")]
+    public void WhenValidating()
+    {
+        _result = SequenceValidator.Validate(_items, e => e.Name, _plan!);
+    }
+
+    [Then("the validation result should be (true|false)")]
+    public void ThenResult(bool expected)
+    {
+        if (_result != expected)
+            throw new Exception($"Expected {expected} but was {_result}");
+    }
+}

--- a/tests/ExampleLib.Tests/SequenceValidatorTests.cs
+++ b/tests/ExampleLib.Tests/SequenceValidatorTests.cs
@@ -62,4 +62,34 @@ public class SequenceValidatorTests
 
         Assert.False(result);
     }
+
+    [Fact]
+    public void Validate_WithPlan_Passes()
+    {
+        var data = new List<Foo>
+        {
+            new Foo { Jar = "a", Car = 10 },
+            new Foo { Jar = "a", Car = 15 },
+            new Foo { Jar = "a", Car = 18 }
+        };
+
+        var plan = new SummarisationPlan<Foo>(f => f.Car, ThresholdType.RawDifference, 5);
+
+        Assert.True(SequenceValidator.Validate(data, f => f.Jar, plan));
+    }
+
+    [Fact]
+    public void Validate_WithPlan_Fails()
+    {
+        var data = new List<Foo>
+        {
+            new Foo { Jar = "a", Car = 10 },
+            new Foo { Jar = "a", Car = 20 },
+            new Foo { Jar = "a", Car = 18 }
+        };
+
+        var plan = new SummarisationPlan<Foo>(f => f.Car, ThresholdType.RawDifference, 5);
+
+        Assert.False(SequenceValidator.Validate(data, f => f.Jar, plan));
+    }
 }


### PR DESCRIPTION
## Summary
- support SummarisationPlan in SequenceValidator
- test plan-based sequence validation
- document new feature and troubleshooting tips
- add BDD scenario for plan-based sequences
- clarify repository layout and quick start steps

## Testing
- `dotnet test --no-restore --no-build -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6874f6ddd3388330aea46e2a5def0e96