### PR TITLE
Fix validation bug and enforce warning policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,9 @@ If you omit the last delegate, equality comparison on the selected value is used
 var plan = new SummarisationPlan<MyEntity>(e => e.Value, ThresholdType.RawDifference, 5);
 bool passes = SequenceValidator.Validate(items, e => e.Server, plan);
 ```
+The validator now checks every item against its immediate predecessor, ensuring
+that sequences with a single key are validated correctly. Use a summarisation
+plan whenever you need a consistent threshold across validations.
 
 ## External Flow Configuration
 Validation flows may be loaded from JSON:
@@ -232,12 +235,17 @@ var json = File.ReadAllText("flows.json");
 var options = ValidationFlowOptions.Load(json);
 services.AddValidationFlows(options);
 ```
+This helper wires up save, commit and delete validations according to the JSON
+definition, reducing boilerplate service registrations.
 
 ## Running the Tests
 Run all unit and BDD tests with code coverage:
 ```bash
 dotnet test --collect:"XPlat Code Coverage"
 ```
+Tests are compiled with warnings treated as errors. Any build warning will fail
+the run, so ensure packages resolve cleanly. The generated coverage report should
+exceed 80% when all tests pass.
 VS Code tasks under `.vscode/tasks.json` provide convenient shortcuts for validating specific scenarios.
 
 ## Additional Guides
@@ -251,6 +259,7 @@ VS Code tasks under `.vscode/tasks.json` provide convenient shortcuts for valida
 - Run `dotnet restore` if packages fail to resolve.
 - Remove `bin` and `obj` folders after SDK upgrades to avoid stale builds.
 - MongoDB tests rely on **Mongo2Go**; ensure the runner can download binaries through your network proxy.
+- If packages resolve to different preview versions, update your project references to avoid NU1603 warnings.
 - If tests fail to compile, verify that all repositories implement the latest interface methods.
 - Missing batch audit data usually means `AddBatchAudit` was not invoked after bulk saves.
 - If results from `SequenceValidator` seem incorrect, verify the items are ordered as intended.

--- a/src/ExampleLib/Domain/ISummarisationValidator.cs
+++ b/src/ExampleLib/Domain/ISummarisationValidator.cs
@@ -10,5 +10,5 @@ public interface ISummarisationValidator<T>
     /// Validates the current entity against the previous audit record using the provided summarisation plan.
     /// Returns true if validation passes (within thresholds), false if the change is out of bounds.
     /// </summary>
-    bool Validate(T currentEntity, SaveAudit previousAudit, SummarisationPlan<T> plan);
+    bool Validate(T currentEntity, SaveAudit? previousAudit, SummarisationPlan<T> plan);
 }

--- a/src/ExampleLib/Domain/SequenceValidator.cs
+++ b/src/ExampleLib/Domain/SequenceValidator.cs
@@ -31,37 +31,17 @@ public static class SequenceValidator
             return true;
 
         var lastItem = enumerator.Current;
-        var lastKey = wheneverSelector(lastItem);
         var lastValue = valueSelector(lastItem);
-        T lastDifferentItem = lastItem;
-        TValue lastDifferentValue = lastValue;
-        TKey lastDifferentKey = lastKey;
-        bool hasLastDifferent = false;
 
         while (enumerator.MoveNext())
         {
             var current = enumerator.Current;
-            var currentKey = wheneverSelector(current);
             var currentValue = valueSelector(current);
 
-            if (!EqualityComparer<TKey>.Default.Equals(currentKey, lastKey))
-            {
-                if (!validationFunc(currentValue, lastValue))
-                    return false;
-
-                lastDifferentItem = lastItem;
-                lastDifferentValue = lastValue;
-                lastDifferentKey = lastKey;
-                hasLastDifferent = true;
-            }
-            else if (hasLastDifferent)
-            {
-                if (!validationFunc(currentValue, lastDifferentValue))
-                    return false;
-            }
+            if (!validationFunc(currentValue, lastValue))
+                return false;
 
             lastItem = current;
-            lastKey = currentKey;
             lastValue = currentValue;
         }
 

--- a/src/ExampleLib/Domain/SummarisationValidator.cs
+++ b/src/ExampleLib/Domain/SummarisationValidator.cs
@@ -10,7 +10,7 @@ namespace ExampleLib.Domain;
 public class SummarisationValidator<T> : ISummarisationValidator<T>
 {
     /// <inheritdoc />
-    public bool Validate(T currentEntity, SaveAudit previousAudit, SummarisationPlan<T> plan)
+    public bool Validate(T currentEntity, SaveAudit? previousAudit, SummarisationPlan<T> plan)
     {
         if (plan == null) throw new ArgumentNullException(nameof(plan));
         if (currentEntity == null) throw new ArgumentNullException(nameof(currentEntity));

--- a/src/ExampleLib/ExampleLib.csproj
+++ b/src/ExampleLib/ExampleLib.csproj
@@ -4,6 +4,7 @@
   <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
@@ -12,14 +13,14 @@
     <PackageReference Include="Serilog" Version="4.3.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.2" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0-preview.3.24172.13" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.0-preview.3.24172.13" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0-preview.4.24267.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.0-preview.4.24267.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.0-preview.4.24267.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.0-preview.4.24267.1">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="MongoDB.Driver" Version="3.4.0" />
-    <PackageReference Include="System.Text.Json" Version="9.0.0-preview.4.24267.1" />
+    <PackageReference Include="System.Text.Json" Version="9.0.0-preview.5.24306.7" />
   </ItemGroup>
 
 </Project>

--- a/src/ExampleLib/Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/ExampleLib/Infrastructure/ServiceCollectionExtensions.cs
@@ -184,7 +184,7 @@ public static class ServiceCollectionExtensions
                 typeof(ServiceCollectionExtensions)
                     .GetMethod(nameof(AddSaveValidation))!
                     .MakeGenericMethod(type)
-                    .Invoke(null, new object[] { services, selector, flow.ThresholdType, flow.ThresholdValue });
+                    .Invoke(null, new object?[] { services, selector, flow.ThresholdType, flow.ThresholdValue });
             }
             if (flow.SaveCommit)
             {

--- a/tests/ExampleLib.BDDTests/ExampleLib.BDDTests.csproj
+++ b/tests/ExampleLib.BDDTests/ExampleLib.BDDTests.csproj
@@ -3,9 +3,10 @@
   <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Mongo2Go" Version="3.1.6" />
+    <PackageReference Include="Mongo2Go" Version="4.0.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="Reqnroll" Version="2.4.1" />
     <PackageReference Include="Reqnroll.Microsoft.Extensions.DependencyInjection" Version="2.4.1" />

--- a/tests/ExampleLib.Tests/ExampleLib.Tests.csproj
+++ b/tests/ExampleLib.Tests/ExampleLib.Tests.csproj
@@ -5,12 +5,13 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="Mongo2Go" Version="3.1.6" />
+    <PackageReference Include="Mongo2Go" Version="4.0.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
     <PackageReference Include="Moq" Version="4.20.72" />


### PR DESCRIPTION
## Summary
- correct SequenceValidator to compare consecutive items
- allow nullable audits in ISummarisationValidator
- update AddValidationFlows to allow null delegate
- bump package versions and treat warnings as errors
- document new behavior, coverage goals and troubleshooting tips

## Testing
- `dotnet test --collect:"XPlat Code Coverage"`

------
https://chatgpt.com/codex/tasks/task_e_6874f9ea57708330a343a16b7926a21b