### PR TITLE
Refactor ManualValidatorService registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,12 +191,19 @@ These helpers register the appropriate repositories and validation services for 
 Entities are validated against the registered `SummarisationPlan` each time a save occurs. The unit of work exposes `SaveChangesWithPlanAsync<TEntity>()` to automatically apply the plan when persisting data. Mongo collections use an interceptor to invoke the same logic whenever documents are inserted or updated.
 
 ## Manual Validators
-`ManualValidatorService` stores simple predicate rules per type. Register the service and rules during startup:
+`ManualValidatorService` exposes a public `Rules` dictionary of predicates keyed by type.
+Create and register the service during startup then add rules as needed:
 ```csharp
 services.AddValidatorService()
         .AddValidatorRule<Order>(o => o.Total > 0);
 ```
 The service evaluates every rule for the specified type and returns `true` only when all pass.
+
+- `AddValidatorService` registers a single `ManualValidatorService` instance.
+- Rules can be added for any type via `AddValidatorRule<T>()`.
+- Access `ManualValidatorService.Rules` from DI to inspect existing predicates.
+- Multiple rules for a type are evaluated sequentially.
+- When no rules exist the service simply returns `true`.
 
 ## Sequence Validation
 `SequenceValidator` provides a lightweight way to compare successive records using lambda expressions. Specify a key selector and value selector; an optional delegate lets you control how values are compared.

--- a/src/ExampleLib/Domain/ManualValidatorService.cs
+++ b/src/ExampleLib/Domain/ManualValidatorService.cs
@@ -9,11 +9,18 @@ namespace ExampleLib.Domain;
 /// </summary>
 public class ManualValidatorService : IManualValidatorService
 {
-    private readonly IDictionary<Type, List<Func<object, bool>>> _rules;
+    /// <summary>
+    /// Dictionary of validation rules keyed by the validated type.
+    /// </summary>
+    public IDictionary<Type, List<Func<object, bool>>> Rules { get; }
+
+    public ManualValidatorService() : this(new Dictionary<Type, List<Func<object, bool>>>())
+    {
+    }
 
     public ManualValidatorService(IDictionary<Type, List<Func<object, bool>>> rules)
     {
-        _rules = rules ?? throw new ArgumentNullException(nameof(rules));
+        Rules = rules ?? throw new ArgumentNullException(nameof(rules));
     }
 
     /// <inheritdoc />
@@ -21,7 +28,7 @@ public class ManualValidatorService : IManualValidatorService
     {
         if (instance == null) throw new ArgumentNullException(nameof(instance));
         var type = instance.GetType();
-        if (!_rules.TryGetValue(type, out var rules) || rules.Count == 0)
+        if (!Rules.TryGetValue(type, out var rules) || rules.Count == 0)
         {
             return true;
         }

--- a/src/ExampleLib/Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/ExampleLib/Infrastructure/ServiceCollectionExtensions.cs
@@ -143,15 +143,15 @@ public static class ServiceCollectionExtensions
         };
     }
 
-    private static readonly IDictionary<Type, List<Func<object, bool>>> _validatorRules = new Dictionary<Type, List<Func<object, bool>>>();
+    private static ManualValidatorService? _manualValidator;
 
     /// <summary>
     /// Register <see cref="ManualValidatorService"/> and the rule dictionary as singletons.
     /// </summary>
     public static IServiceCollection AddValidatorService(this IServiceCollection services)
     {
-        services.AddSingleton(_validatorRules);
-        services.AddSingleton<IManualValidatorService>(new ManualValidatorService(_validatorRules));
+        _manualValidator ??= new ManualValidatorService();
+        services.AddSingleton<IManualValidatorService>(_manualValidator);
         return services;
     }
 
@@ -160,10 +160,11 @@ public static class ServiceCollectionExtensions
     /// </summary>
     public static IServiceCollection AddValidatorRule<T>(this IServiceCollection services, Func<T, bool> rule)
     {
-        if (!_validatorRules.TryGetValue(typeof(T), out var list))
+        _manualValidator ??= new ManualValidatorService();
+        if (!_manualValidator.Rules.TryGetValue(typeof(T), out var list))
         {
             list = new List<Func<object, bool>>();
-            _validatorRules[typeof(T)] = list;
+            _manualValidator.Rules[typeof(T)] = list;
         }
         list.Add(o => rule((T)o));
         return services;

--- a/tests/ExampleLib.BDDTests/AddSetupValidationSteps.cs
+++ b/tests/ExampleLib.BDDTests/AddSetupValidationSteps.cs
@@ -25,7 +25,7 @@ public class AddSetupValidationSteps
         _services!.AddSetupValidation<YourEntity>(
             b => b.UseSqlServer<YourDbContext>("DataSource=:memory:"),
             e => e.Id);
-        _provider = _services.BuildServiceProvider();
+        _provider = _services!.BuildServiceProvider();
     }
 
     [When("AddSetupValidation is invoked with Mongo")]
@@ -34,7 +34,7 @@ public class AddSetupValidationSteps
         _services!.AddSetupValidation<YourEntity>(
             b => b.UseMongo("mongodb://localhost:27017", "bdd"),
             e => e.Id);
-        _provider = _services.BuildServiceProvider();
+        _provider = _services!.BuildServiceProvider();
     }
 
     [Then("a repository and validator can be resolved")]

--- a/tests/ExampleLib.BDDTests/AddValidatorServiceSteps.cs
+++ b/tests/ExampleLib.BDDTests/AddValidatorServiceSteps.cs
@@ -22,14 +22,14 @@ public class AddValidatorServiceSteps
     public void WhenAddValidatorServiceInvoked()
     {
         _services!.AddValidatorService();
-        _provider = _services.BuildServiceProvider();
+        _provider = _services!.BuildServiceProvider();
     }
 
     [When("AddValidatorRule is invoked")]
     public void WhenAddValidatorRuleInvoked()
     {
         _services!.AddValidatorRule<object>(_ => true);
-        _provider = _services.BuildServiceProvider();
+        _provider = _services!.BuildServiceProvider();
     }
 
     [Then("the manual validator can be resolved")]

--- a/tests/ExampleLib.BDDTests/ExtensionRegistrationSteps.cs
+++ b/tests/ExampleLib.BDDTests/ExtensionRegistrationSteps.cs
@@ -23,13 +23,13 @@ public class ExtensionRegistrationSteps
     public void WhenInvoked()
     {
         _services!.AddSaveValidation<YourEntity>(e => e.Id);
-        _provider = _services.BuildServiceProvider();
+        _provider = _services!.BuildServiceProvider();
     }
 
     [Then("a repository and validator can be resolved")]
     public void ThenServicesResolvable()
     {
         Assert.NotNull(_provider!.GetService<IEntityRepository<YourEntity>>());
-        Assert.NotNull(_provider.GetService<ISummarisationValidator<YourEntity>>());
+        Assert.NotNull(_provider!.GetService<ISummarisationValidator<YourEntity>>());
     }
 }

--- a/tests/ExampleLib.BDDTests/MongoConfigurationSteps.cs
+++ b/tests/ExampleLib.BDDTests/MongoConfigurationSteps.cs
@@ -22,7 +22,7 @@ public class MongoConfigurationSteps
     public void WhenAddExampleDataMongoInvoked()
     {
         _services!.AddExampleDataMongo("mongodb://localhost:27017", "bdd");
-        _provider = _services.BuildServiceProvider();
+        _provider = _services!.BuildServiceProvider();
     }
 
     [Then("the Mongo database should resolve")]

--- a/tests/ExampleLib.BDDTests/SetupDatabaseSteps.cs
+++ b/tests/ExampleLib.BDDTests/SetupDatabaseSteps.cs
@@ -21,7 +21,7 @@ public class SetupDatabaseSteps
     public void WhenSetupDatabaseInvoked()
     {
         _services!.SetupDatabase<YourDbContext>("DataSource=:memory:");
-        _provider = _services.BuildServiceProvider();
+        _provider = _services!.BuildServiceProvider();
     }
 
     [Then("a unit of work can be resolved")]

--- a/tests/ExampleLib.BDDTests/SetupMongoDatabaseSteps.cs
+++ b/tests/ExampleLib.BDDTests/SetupMongoDatabaseSteps.cs
@@ -21,7 +21,7 @@ public class SetupMongoDatabaseSteps
     public void WhenSetupMongoDatabaseInvoked()
     {
         _services!.SetupMongoDatabase("mongodb://localhost:27017", "bdd");
-        _provider = _services.BuildServiceProvider();
+        _provider = _services!.BuildServiceProvider();
     }
 
     [Then("a Mongo unit of work can be resolved")]

--- a/tests/ExampleLib.BDDTests/SqlServerConfigurationSteps.cs
+++ b/tests/ExampleLib.BDDTests/SqlServerConfigurationSteps.cs
@@ -22,7 +22,7 @@ public class SqlServerConfigurationSteps
     public void WhenAddExampleDataSqlServerInvoked()
     {
         _services!.AddExampleDataSqlServer("Server=(localdb)\\mssqllocaldb;Database=BDD;Trusted_Connection=True;");
-        _provider = _services.BuildServiceProvider();
+        _provider = _services!.BuildServiceProvider();
     }
 
     [Then("the DbContext should use SqlServer")]


### PR DESCRIPTION
## Summary
- move rules dictionary into ManualValidatorService
- register a single instance from AddValidatorService
- adapt BDD step definitions to use null-forgiving operator
- document new design in README

## Testing
- `dotnet test --no-build --nologo RAGStart.sln`

------
https://chatgpt.com/codex/tasks/task_e_6874ffe78a788330b1adf17903a6e472