### PR TITLE
Add threshold helper and unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ RAGStart provides a reference implementation of an event‑driven validation pip
 7. Record bulk saves with `AddBatchAudit` so later validations know the previous batch size.
 8. Leverage `SequenceValidator` for on-the-fly comparisons between successive records.
 9. Use `SequenceValidator` with a `SummarisationPlan` when the same threshold logic should apply across sequences.
+10. Centralise metric checks with `ThresholdValidator.IsWithinThreshold` for consistent results.
+11. Include the `ExampleLib.Domain` namespace when using this helper in your own code.
 
 ## Repository Layout
 - `src/ExampleLib` – domain models and infrastructure.
@@ -216,6 +218,10 @@ The validator now checks every item against its immediate predecessor, ensuring
 that sequences with a single key are validated correctly. Use a summarisation
 plan whenever you need a consistent threshold across validations.
 
+`ThresholdValidator.IsWithinThreshold` exposes the same logic for custom
+scenarios. Pass `throwOnUnsupported: true` to surface unexpected values when
+validating your own data.
+
 ## External Flow Configuration
 Validation flows may be loaded from JSON:
 ```json
@@ -253,6 +259,7 @@ VS Code tasks under `.vscode/tasks.json` provide convenient shortcuts for valida
 - `Implementation.md` discusses designing class libraries at different maturity levels.
 - The new `RepositoryUpdate.feature` demonstrates updating entities via BDD tests.
 - `SequencePlan.feature` shows plan-based sequence validation in action.
+- `ThresholdValidator.cs` demonstrates consolidating change thresholds in one place.
 
 ## Troubleshooting
 - Ensure `DOTNET_ROLL_FORWARD=Major` is set when using .NET 9 runtimes.
@@ -264,4 +271,5 @@ VS Code tasks under `.vscode/tasks.json` provide convenient shortcuts for valida
 - Missing batch audit data usually means `AddBatchAudit` was not invoked after bulk saves.
 - If results from `SequenceValidator` seem incorrect, verify the items are ordered as intended.
 - When using a plan with `SequenceValidator`, ensure the threshold values match your expectations.
+- When writing custom comparisons, use `ThresholdValidator.IsWithinThreshold` so behaviour mirrors the built-in validators.
 

--- a/src/ExampleLib/Domain/SequenceValidator.cs
+++ b/src/ExampleLib/Domain/SequenceValidator.cs
@@ -71,18 +71,11 @@ public static class SequenceValidator
         if (plan == null) throw new ArgumentNullException(nameof(plan));
 
         return Validate(items, wheneverSelector, plan.MetricSelector, (cur, prev) =>
-        {
-            switch (plan.ThresholdType)
-            {
-                case ThresholdType.RawDifference:
-                    return Math.Abs(cur - prev) <= plan.ThresholdValue;
-                case ThresholdType.PercentChange:
-                    if (prev == 0) return cur == 0;
-                    var change = Math.Abs((cur - prev) / prev);
-                    return change <= plan.ThresholdValue;
-                default:
-                    throw new NotSupportedException($"Unsupported ThresholdType: {plan.ThresholdType}");
-            }
-        });
+            ThresholdValidator.IsWithinThreshold(
+                cur,
+                prev,
+                plan.ThresholdType,
+                plan.ThresholdValue,
+                throwOnUnsupported: true));
     }
 }

--- a/src/ExampleLib/Domain/SummarisationValidator.cs
+++ b/src/ExampleLib/Domain/SummarisationValidator.cs
@@ -26,25 +26,10 @@ public class SummarisationValidator<T> : ISummarisationValidator<T>
 
         decimal previousValue = previousAudit.MetricValue;
 
-        switch (plan.ThresholdType)
-        {
-            case ThresholdType.RawDifference:
-                var diff = currentValue - previousValue;
-                return Math.Abs(diff) <= plan.ThresholdValue;
-
-            case ThresholdType.PercentChange:
-                if (previousValue == 0)
-                {
-                    // If previous value was zero, treat any non-zero change as exceeding
-                    return currentValue == 0;
-                }
-
-                var changeFraction = Math.Abs((currentValue - previousValue) / previousValue);
-                return changeFraction <= plan.ThresholdValue;
-
-            default:
-                // Unknown threshold type - treat as valid
-                return true;
-        }
+        return ThresholdValidator.IsWithinThreshold(
+            currentValue,
+            previousValue,
+            plan.ThresholdType,
+            plan.ThresholdValue);
     }
 }

--- a/src/ExampleLib/Domain/ThresholdValidator.cs
+++ b/src/ExampleLib/Domain/ThresholdValidator.cs
@@ -1,0 +1,43 @@
+using System;
+
+namespace ExampleLib.Domain;
+
+/// <summary>
+/// Provides helper methods for validating metric changes against thresholds.
+/// </summary>
+public static class ThresholdValidator
+{
+    /// <summary>
+    /// Determines if the difference between the current and previous value
+    /// falls within the allowed threshold.
+    /// </summary>
+    /// <param name="current">Current metric value.</param>
+    /// <param name="previous">Previous metric value.</param>
+    /// <param name="type">Type of comparison to perform.</param>
+    /// <param name="threshold">Allowed threshold value.</param>
+    /// <param name="throwOnUnsupported">Throw when the <see cref="ThresholdType"/> is not recognised.</param>
+    public static bool IsWithinThreshold(
+        decimal current,
+        decimal previous,
+        ThresholdType type,
+        decimal threshold,
+        bool throwOnUnsupported = false)
+    {
+        switch (type)
+        {
+            case ThresholdType.RawDifference:
+                return Math.Abs(current - previous) <= threshold;
+            case ThresholdType.PercentChange:
+                if (previous == 0)
+                {
+                    return current == 0;
+                }
+                var changeFraction = Math.Abs((current - previous) / previous);
+                return changeFraction <= threshold;
+            default:
+                if (throwOnUnsupported)
+                    throw new NotSupportedException($"Unsupported ThresholdType: {type}");
+                return true;
+        }
+    }
+}

--- a/tests/ExampleLib.Tests/SequenceValidatorTests.cs
+++ b/tests/ExampleLib.Tests/SequenceValidatorTests.cs
@@ -92,4 +92,19 @@ public class SequenceValidatorTests
 
         Assert.False(SequenceValidator.Validate(data, f => f.Jar, plan));
     }
+
+    [Fact]
+    public void Validate_WithUnsupportedPlanType_Throws()
+    {
+        var data = new List<Foo>
+        {
+            new Foo { Jar = "x", Car = 1 },
+            new Foo { Jar = "x", Car = 2 }
+        };
+
+        var plan = new SummarisationPlan<Foo>(f => f.Car, (ThresholdType)999, 0m);
+
+        Assert.Throws<NotSupportedException>(() =>
+            SequenceValidator.Validate(data, f => f.Jar, plan));
+    }
 }

--- a/tests/ExampleLib.Tests/SummarisationValidatorTests.cs
+++ b/tests/ExampleLib.Tests/SummarisationValidatorTests.cs
@@ -42,4 +42,16 @@ public class SummarisationValidatorTests
 
         Assert.False(result);
     }
+
+    [Fact]
+    public void UnknownThresholdType_ReturnsTrue()
+    {
+        var plan = new SummarisationPlan<YourEntity>(e => e.Id, (ThresholdType)999, 1m);
+        var entity = new YourEntity { Id = 1 };
+        var previous = new SaveAudit { MetricValue = 1 };
+
+        var result = _validator.Validate(entity, previous, plan);
+
+        Assert.True(result);
+    }
 }

--- a/tests/ExampleLib.Tests/ThresholdValidatorTests.cs
+++ b/tests/ExampleLib.Tests/ThresholdValidatorTests.cs
@@ -1,0 +1,16 @@
+using ExampleLib.Domain;
+using System;
+using Xunit;
+
+namespace ExampleLib.Tests;
+
+public class ThresholdValidatorTests
+{
+    [Fact]
+    public void ThrowsOnUnsupportedType_WhenRequested()
+    {
+        Assert.Throws<NotSupportedException>(() =>
+            ThresholdValidator.IsWithinThreshold(10, 5, (ThresholdType)123, 1m, true));
+    }
+}
+


### PR DESCRIPTION
## Summary
- centralize threshold logic into a new `ThresholdValidator` helper
- refactor `SequenceValidator` and `SummarisationValidator` to use the helper
- expand README with usage guidance for `ThresholdValidator`
- add tests for unsupported threshold types

## Testing
- `dotnet test tests/ExampleLib.Tests/ExampleLib.Tests.csproj --no-restore --no-build -v minimal`
- `dotnet test tests/ExampleLib.Tests/ExampleLib.Tests.csproj --collect:"XPlat Code Coverage" --no-restore --no-build -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_6874ffe377488330bebf52255efecba7