### PR TITLE
Refactor ValidationRunner API

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ RAGStart showcases an event-driven validation pipeline built with .NET. The proj
 ## Getting Started
 1. Install the [.NET&nbsp;9 SDK](https://dotnet.microsoft.com/en-us/download).
 2. Set the environment variable `DOTNET_ROLL_FORWARD=Major` when using .NET 9 runtimes.
+   On Linux you can export this in your shell profile so builds are consistent.
 3. Run `dotnet build` then `dotnet test --collect:"XPlat Code Coverage"` to compile and execute all tests.
 4. Reference `ExampleLib` in your own project and register services as shown below.
 5. Use `AddManyAsync` and `UpdateManyAsync` for efficient bulk operations.
@@ -64,10 +65,13 @@ services.AddExampleLib(builder =>
     builder.UseEf<TestDbContext>(options => options.UseSqlServer("connection"));
 });
 ```
+Replace `"connection"` with your actual connection string. For SQLite or PostgreSQL simply call the corresponding `Use*` method on the builder.
 Switch to MongoDB by calling `UseMongo` instead. Both providers expose `AddBatchAudit` for summarising bulk saves.
 
 ## Validation Pipeline
 Entities are validated against a `SummarisationPlan` whenever they are saved. The Entity Framework unit of work exposes `SaveChangesWithPlanAsync<TEntity>()`, while the MongoDB implementation uses an interceptor to apply the same logic during inserts and updates.
+
+You can register multiple plans if different thresholds are needed. Each plan captures the metric selector and allowed variance for a specific entity type.
 
 ## Manual Validation Service
 `ManualValidatorService` lets you register predicates to run against specific types:
@@ -85,6 +89,8 @@ services.AddValidationRunner();
 ```
 `AddValidationRunner` registers a single service that executes every validator so existing repositories can enable validation in one line.
 
+`AddValidatorRule` requires entities to implement `IValidatable`, `IBaseEntity` and `IRootEntity` ensuring only valid domain models can be registered.
+
 ## Using ValidationRunner
 Once registered, request `IValidationRunner` from the service provider and call `ValidateAsync`
 before persisting changes. This integrates validation with any repository:
@@ -95,9 +101,11 @@ var repo = new EfGenericRepository<Order>(provider.GetRequiredService<DbContext>
 var order = new Order { Id = 1, Total = 5, Status = "Open", Validated = true };
 await repo.AddAsync(order);
 await provider.GetRequiredService<DbContext>().SaveChangesAsync();
-bool ok = await runner.ValidateAsync(order, order.Id.ToString());
+bool ok = await runner.ValidateAsync(order);
 ```
 `ok` indicates whether both summarisation and manual checks succeeded.
+
+`ValidateAsync` now derives the identifier from `order.Id`, so callers no longer need to pass an explicit string.
 
 ## Validating Sequences
 `SequenceValidator` compares successive items in a sequence. Provide key and value selectors with an optional comparison delegate:
@@ -139,6 +147,7 @@ Run the unit tests with coverage:
 dotnet test --collect:"XPlat Code Coverage"
 ```
 The generated coverage report appears under `TestResults` and should exceed 80%.
+Open the `.cobertura.xml` file in Visual Studio Code with the C# extension to visualise line-by-line results.
 For quick iterations run:
 ```bash
 dotnet test --no-build --no-restore

--- a/src/ExampleLib/Domain/IValidationRunner.cs
+++ b/src/ExampleLib/Domain/IValidationRunner.cs
@@ -9,5 +9,6 @@ public interface IValidationRunner
     /// Validate and audit the specified entity.
     /// Returns <c>true</c> when all validation services succeed.
     /// </summary>
-    Task<bool> ValidateAsync<T>(T entity, string entityId, CancellationToken cancellationToken = default);
+    Task<bool> ValidateAsync<T>(T entity, CancellationToken cancellationToken = default)
+        where T : IValidatable, IBaseEntity, IRootEntity;
 }

--- a/src/ExampleLib/Domain/IValidationService.cs
+++ b/src/ExampleLib/Domain/IValidationService.cs
@@ -9,5 +9,6 @@ public interface IValidationService
     /// Validate the entity and persist an audit entry.
     /// Returns <c>true</c> when the entity passes validation.
     /// </summary>
-    Task<bool> ValidateAndSaveAsync<T>(T entity, string entityId, CancellationToken cancellationToken = default);
+    Task<bool> ValidateAndSaveAsync<T>(T entity, CancellationToken cancellationToken = default)
+        where T : IValidatable, IBaseEntity, IRootEntity;
 }

--- a/src/ExampleLib/Infrastructure/MongoCollectionInterceptor.cs
+++ b/src/ExampleLib/Infrastructure/MongoCollectionInterceptor.cs
@@ -39,7 +39,7 @@ public class MongoCollectionInterceptor<T> : IMongoCollectionInterceptor<T>
     public async Task InsertOneAsync(T document, CancellationToken cancellationToken = default)
     {
         await _inner.InsertOneAsync(document, cancellationToken: cancellationToken);
-        await _validationService.ValidateAndSaveAsync(document, document.Id.ToString(), cancellationToken);
+        await _validationService.ValidateAndSaveAsync(document, cancellationToken);
     }
 
     public async Task<UpdateResult> UpdateOneAsync(FilterDefinition<T> filter, UpdateDefinition<T> update, CancellationToken cancellationToken = default)
@@ -50,7 +50,7 @@ public class MongoCollectionInterceptor<T> : IMongoCollectionInterceptor<T>
             var updated = await _inner.Find(filter).FirstOrDefaultAsync(cancellationToken);
             if (updated != null)
             {
-                await _validationService.ValidateAndSaveAsync(updated, updated.Id.ToString(), cancellationToken);
+                await _validationService.ValidateAndSaveAsync(updated, cancellationToken);
             }
         }
         return result;
@@ -59,7 +59,7 @@ public class MongoCollectionInterceptor<T> : IMongoCollectionInterceptor<T>
     public async Task ReplaceOneAsync(FilterDefinition<T> filter, T replacement, CancellationToken cancellationToken = default)
     {
         await _inner.ReplaceOneAsync(filter, replacement, cancellationToken: cancellationToken);
-        await _validationService.ValidateAndSaveAsync(replacement, replacement.Id.ToString(), cancellationToken);
+        await _validationService.ValidateAndSaveAsync(replacement, cancellationToken);
     }
 
     public Task<DeleteResult> DeleteOneAsync(FilterDefinition<T> filter, CancellationToken cancellationToken = default)

--- a/src/ExampleLib/Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/ExampleLib/Infrastructure/ServiceCollectionExtensions.cs
@@ -24,6 +24,7 @@ public static class ServiceCollectionExtensions
         ThresholdType thresholdType = ThresholdType.PercentChange,
         decimal thresholdValue = 0.1m,
         params Func<T, bool>[] manualRules)
+        where T : class, IValidatable, IBaseEntity, IRootEntity
     {
         services.AddSingleton(typeof(ISummarisationValidator<>), typeof(SummarisationValidator<>));
         services.AddSingleton<ISaveAuditRepository, InMemorySaveAuditRepository>();
@@ -50,6 +51,7 @@ public static class ServiceCollectionExtensions
     /// Placeholder for backwards compatibility. Currently performs no registration.
     /// </summary>
     public static IServiceCollection AddSaveCommit<T>(this IServiceCollection services)
+        where T : class, IValidatable, IBaseEntity, IRootEntity
     {
         return services;
     }
@@ -58,6 +60,7 @@ public static class ServiceCollectionExtensions
     /// Register the services required to validate delete requests for <typeparamref name="T"/>.
     /// </summary>
     public static IServiceCollection AddDeleteValidation<T>(this IServiceCollection services)
+        where T : class, IValidatable, IBaseEntity, IRootEntity
     {
         services.AddValidatorService();
         return services;
@@ -67,6 +70,7 @@ public static class ServiceCollectionExtensions
     /// Register the services required to commit deletes for <typeparamref name="T"/>.
     /// </summary>
     public static IServiceCollection AddDeleteCommit<T>(this IServiceCollection services)
+        where T : class, IValidatable, IBaseEntity, IRootEntity
     {
         return services;
     }
@@ -89,6 +93,7 @@ public static class ServiceCollectionExtensions
         ThresholdType thresholdType = ThresholdType.PercentChange,
         decimal thresholdValue = 0.1m,
         params Func<T, bool>[] manualRules)
+        where T : class, IValidatable, IBaseEntity, IRootEntity
     {
         var builder = new SetupValidationBuilder();
         configure(builder);
@@ -177,6 +182,7 @@ public static class ServiceCollectionExtensions
     /// Add a manual validation rule for the specified type.
     /// </summary>
     public static IServiceCollection AddValidatorRule<T>(this IServiceCollection services, Func<T, bool> rule)
+        where T : class, IValidatable, IBaseEntity, IRootEntity
     {
         _manualValidator ??= new ManualValidatorService();
         if (!_manualValidator.Rules.TryGetValue(typeof(T), out var list))

--- a/src/ExampleLib/Infrastructure/UnitOfWork.cs
+++ b/src/ExampleLib/Infrastructure/UnitOfWork.cs
@@ -45,7 +45,7 @@ public class UnitOfWork<TContext> : IUnitOfWork where TContext : DbContext
         foreach (var entry in _context.ChangeTracker.Entries<TEntity>()
                      .Where(e => e.State == EntityState.Added || e.State == EntityState.Modified))
         {
-            var isValid = await _validationService.ValidateAndSaveAsync(entry.Entity, entry.Entity.Id.ToString(), cancellationToken);
+            var isValid = await _validationService.ValidateAndSaveAsync(entry.Entity, cancellationToken);
             entry.Entity.Validated = isValid;
         }
 
@@ -58,7 +58,7 @@ public class UnitOfWork<TContext> : IUnitOfWork where TContext : DbContext
         foreach (var entry in _context.ChangeTracker.Entries<TEntity>()
                      .Where(e => e.State == EntityState.Added || e.State == EntityState.Modified))
         {
-            var isValid = await _validationService.ValidateAndSaveAsync(entry.Entity, entry.Entity.Id.ToString(), cancellationToken);
+            var isValid = await _validationService.ValidateAndSaveAsync(entry.Entity, cancellationToken);
             entry.Entity.Validated = isValid;
         }
 

--- a/src/ExampleLib/Infrastructure/ValidationRunner.cs
+++ b/src/ExampleLib/Infrastructure/ValidationRunner.cs
@@ -17,9 +17,10 @@ public class ValidationRunner : IValidationRunner
     }
 
     /// <inheritdoc />
-    public async Task<bool> ValidateAsync<T>(T entity, string entityId, CancellationToken cancellationToken = default)
+    public async Task<bool> ValidateAsync<T>(T entity, CancellationToken cancellationToken = default)
+        where T : IValidatable, IBaseEntity, IRootEntity
     {
-        var summaryValid = await _validationService.ValidateAndSaveAsync(entity!, entityId, cancellationToken);
+        var summaryValid = await _validationService.ValidateAndSaveAsync(entity!, cancellationToken);
         var manualValid = _manualValidator.Validate(entity!);
         return summaryValid && manualValid;
     }

--- a/src/ExampleLib/Infrastructure/ValidationService.cs
+++ b/src/ExampleLib/Infrastructure/ValidationService.cs
@@ -20,8 +20,10 @@ public class ValidationService : IValidationService
     }
 
     /// <inheritdoc />
-    public Task<bool> ValidateAndSaveAsync<T>(T entity, string entityId, CancellationToken cancellationToken = default)
+    public Task<bool> ValidateAndSaveAsync<T>(T entity, CancellationToken cancellationToken = default)
+        where T : IValidatable, IBaseEntity, IRootEntity
     {
+        var entityId = entity!.Id.ToString();
         var plan = _planStore.GetPlan<T>();
         var validator = _provider.GetRequiredService<ISummarisationValidator<T>>();
         var previous = _auditRepository.GetLastAudit(typeof(T).Name, entityId);

--- a/tests/ExampleLib.Tests/RepositoryTests.cs
+++ b/tests/ExampleLib.Tests/RepositoryTests.cs
@@ -150,7 +150,8 @@ public class RepositoryTests
 
     private class NoopValidationService : ExampleLib.Domain.IValidationService
     {
-        public Task<bool> ValidateAndSaveAsync<T>(T entity, string entityId, CancellationToken cancellationToken = default)
+        public Task<bool> ValidateAndSaveAsync<T>(T entity, CancellationToken cancellationToken = default)
+            where T : IValidatable, IBaseEntity, IRootEntity
             => Task.FromResult(true);
     }
 

--- a/tests/ExampleLib.Tests/ValidationRunnerTests.cs
+++ b/tests/ExampleLib.Tests/ValidationRunnerTests.cs
@@ -26,7 +26,7 @@ public class ValidationRunnerTests
         await repo.AddAsync(entity);
         await provider.GetRequiredService<YourDbContext>().SaveChangesAsync();
 
-        var result = await runner.ValidateAsync(entity, entity.Id.ToString());
+        var result = await runner.ValidateAsync(entity);
         Assert.True(result);
     }
 
@@ -47,7 +47,7 @@ public class ValidationRunnerTests
         await repo.AddAsync(entity);
         await provider.GetRequiredService<YourDbContext>().SaveChangesAsync();
 
-        var result = await runner.ValidateAsync(entity, entity.Id.ToString());
+        var result = await runner.ValidateAsync(entity);
         Assert.False(result);
     }
 
@@ -55,24 +55,17 @@ public class ValidationRunnerTests
     public async Task ValidateAsync_ReturnsFalse_WhenSummarisationRuleFails()
     {
         var services = new ServiceCollection();
-        services.AddDbContext<YourDbContext>(o => o.UseInMemoryDatabase("summary-fail"));
-        services.AddSaveValidation<YourEntity>(e => e.Id, ThresholdType.RawDifference, 1m,
+        services.AddSaveValidation<YourEntity>(e => (decimal)e.Timestamp.Ticks, ThresholdType.RawDifference, 1m,
             e => true);
         services.AddValidationRunner();
         var provider = services.BuildServiceProvider();
-        var context = provider.GetRequiredService<YourDbContext>();
-        var repo = new EfGenericRepository<YourEntity>(context);
         var runner = provider.GetRequiredService<IValidationRunner>();
 
-        var first = new YourEntity { Id = 1, Name = "One", Validated = true };
-        await repo.AddAsync(first);
-        await provider.GetRequiredService<YourDbContext>().SaveChangesAsync();
-        await runner.ValidateAsync(first, "X");
+        var entity = new YourEntity { Id = 1, Name = "One", Timestamp = DateTime.UtcNow, Validated = true };
+        await runner.ValidateAsync(entity);
 
-        var second = new YourEntity { Id = 5, Name = "Two", Validated = true };
-        await repo.AddAsync(second);
-        await provider.GetRequiredService<YourDbContext>().SaveChangesAsync();
-        var result = await runner.ValidateAsync(second, "X");
+        entity.Timestamp = entity.Timestamp.AddMinutes(5);
+        var result = await runner.ValidateAsync(entity);
 
         Assert.False(result);
     }


### PR DESCRIPTION
## Summary
- simplify `ValidateAsync` by relying on entity `Id`
- constrain validation registration helpers to valid entities
- refactor validation service and unit of work to use the new ID lookup
- update Mongo collection interceptor and tests
- document new workflow in README

## Testing
- `dotnet test --no-build --no-restore`
- `dotnet test --collect:"XPlat Code Coverage"`

------
https://chatgpt.com/codex/tasks/task_e_687582c9853883308a120275f63083d2