### PR TITLE
Expand README and fix validation tests

### DIFF
--- a/tests/ExampleLib.Tests/ValidationRunnerTests.cs
+++ b/tests/ExampleLib.Tests/ValidationRunnerTests.cs
@@ -57,13 +57,8 @@ public class ValidationRunnerTests
     public async Task ValidateAsync_ReturnsFalse_WhenSummarisationRuleFails()
     {
         var services = new ServiceCollection();
-<<<<<< codex/update-validation-runner-interface-and-usage
-        services.AddSaveValidation<YourEntity>(e => (decimal)e.Timestamp.Ticks, ThresholdType.RawDifference, 1m,
-=====
         services.AddSingleton<IApplicationNameProvider>(new StaticApplicationNameProvider("Tests"));
-        services.AddDbContext<YourDbContext>(o => o.UseInMemoryDatabase("summary-fail"));
-        services.AddSaveValidation<YourEntity>(e => e.Id, ThresholdType.RawDifference, 1m,
->>>>>> Restructure
+        services.AddSaveValidation<YourEntity>(e => (decimal)e.Timestamp.Ticks, ThresholdType.RawDifference, 1m,
             e => true);
         services.AddValidationRunner();
         var provider = services.BuildServiceProvider();


### PR DESCRIPTION
## Summary
- fix merge markers in `ValidationRunnerTests`
- register `IApplicationNameProvider` in tests
- document ApplicationName usage in README
- describe base entity requirements and updated ValidationRunner signature
- clarify sequence validation guidance
- add troubleshooting note for mismatched application names

## Testing
- `dotnet test --no-build --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_6875884e6df88330a8f6dd6d8fd66082